### PR TITLE
Make OrdinaryDiffEq and ForwardDiff optional

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,10 @@ version = "0.1.0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
@@ -19,11 +18,12 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 [extras]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DoubleFloats", "ForwardDiff", "ReverseDiff"]
+test = ["Test", "DoubleFloats", "ForwardDiff", "OrdinaryDiffEq", "ReverseDiff"]
 
 [compat]
 julia = "1.0"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -23,6 +23,7 @@ import LinearAlgebra: dot,
     I,
     UniformScaling,
     Diagonal
+using Requires
 using StaticArrays
 import Markdown: @doc_str
 import Distributions: _rand!, support
@@ -30,13 +31,8 @@ import Random: rand
 using LinearAlgebra
 using Random: AbstractRNG
 using SimpleTraits
-using ForwardDiff
 using UnsafeArrays
 using Einsum: @einsum
-using OrdinaryDiffEq: ODEProblem,
-    AutoVern9,
-    Rodas5,
-    solve
 
 """
     Manifold
@@ -641,6 +637,21 @@ include("ProductManifold.jl")
 include("Rotations.jl")
 include("Sphere.jl")
 include("ProjectedDistribution.jl")
+
+function __init__()
+    @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
+        using ForwardDiff
+        include("forward_diff.jl")
+    end
+
+    @require OrdinaryDiffEq="1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
+        using OrdinaryDiffEq: ODEProblem,
+            AutoVern9,
+            Rodas5,
+            solve
+        include("ode.jl")
+    end
+end
 
 export ArrayManifold,
     ArrayMPoint,

--- a/src/Metric.jl
+++ b/src/Metric.jl
@@ -124,7 +124,10 @@ Get partial derivatives of the local metric of `M` at `x` with respect to the
 coordinates of `x`, $\frac{\partial}{\partial x^k} g_{ij} = g_{ij,k}$. The
 dimensions of the resulting multi-dimensional array are ordered $(i,j,k)$.
 """
-function local_metric_jacobian end
+function local_metric_jacobian(M, x)
+    error("local_metric_jacobian not implemented on $(typeof(M)) for point $(typeof(x)). For a suitable default, enter `using ForwardDiff`.")
+end
+
 
 @traitfn function inner(M::MMT, x, v, w) where {MT<:Manifold,
                                                 GT<:Metric,
@@ -232,7 +235,9 @@ for manifold `M` at `x` with respect to the coordinates of `x`,
 $\frac{\partial}{\partial x^l} \Gamma^{k}_{ij} = \Gamma^{k}_{ij,l}.$
 The dimensions of the resulting multi-dimensional array are ordered $(i,j,k,l)$.
 """
-function christoffel_symbols_second_jacobian end
+function christoffel_symbols_second_jacobian(M, x)
+    error("christoffel_symbols_second_jacobian not implemented on $(typeof(M)) for point $(typeof(x)). For a suitable default, enter `using ForwardDiff`.")
+end
 
 @doc doc"""
     riemann_tensor(M::MetricManifold, x)
@@ -295,6 +300,56 @@ function einstein_tensor(M::MetricManifold, x)
     S = sum(ginv .* Ric)
     G = Ric - g .* S / 2
     return G
+end
+
+@doc doc"""
+    solve_exp_ode(M::MetricManifold,
+                  x,
+                  v,
+                  tspan;
+                  solver=AutoVern9(Rodas5()),
+                  kwargs...)
+
+Approximate the exponential map on the manifold over the provided timespan
+assuming the Levi-Civita connection by solving the ordinary differential
+equation
+
+$\frac{d^2}{dt^2} x^k + \Gamma^k_{ij} \frac{d}{dt} x_i \frac{d}{dt} x_j = 0,$
+
+where $\Gamma^k_{ij}$ are the Christoffel symbols of the second kind, and
+the Einstein summation convention is assumed. The arguments `tspan` and
+`solver` follow the `OrdinaryDiffEq` conventions. `kwargs...` specify keyword
+arguments that will be passed to `OrdinaryDiffEq.solve`.
+
+Currently, the numerical integration is only accurate when using a single
+coordinate chart that covers the entire manifold. This excludes coordinates
+in an embedded space.
+"""
+function solve_exp_ode(M, x, v, tspan; kwargs...)
+    error("solve_exp_ode not implemented on $(typeof(M)) for point $(typeof(x)), vector $(typeof(y)), and timespan $(typeof(tspan)). For a suitable default, enter `using OrdinaryDiffEq`.")
+end
+
+@traitfn function exp(M::MMT,
+                      x,
+                      v,
+                      T::AbstractVector) where {MT<:Manifold,
+                                                GT<:Metric,
+                                                MMT<:MetricManifold{MT,GT};
+                                                !HasMetric{MT,GT}}
+    sol = solve_exp_ode(M, x, v, extrema(T); dense=false, saveat=T)
+    n = length(x)
+    return map(i -> sol.u[i][n+1:end], 1:length(T))
+end
+
+@traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
+                                               GT<:Metric,
+                                               MMT<:MetricManifold{MT,GT};
+                                               !HasMetric{MT,GT}}
+    tspan = (0.0, 1.0)
+    sol = solve_exp_ode(M, x, v, tspan; dense=false, saveat=[1.0])
+    n = length(x)
+    y .= sol.u[1][n+1:end]
+    return y
 end
 
 """

--- a/src/Metric.jl
+++ b/src/Metric.jl
@@ -341,17 +341,6 @@ end
     return map(i -> sol.u[i][n+1:end], 1:length(T))
 end
 
-@traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
-                                               GT<:Metric,
-                                               MMT<:MetricManifold{MT,GT};
-                                               !HasMetric{MT,GT}}
-    tspan = (0.0, 1.0)
-    sol = solve_exp_ode(M, x, v, tspan; dense=false, saveat=[1.0])
-    n = length(x)
-    y .= sol.u[1][n+1:end]
-    return y
-end
-
 """
     exp(M::MetricManifold, x, v, args...)
 
@@ -364,6 +353,17 @@ coordinate chart that covers the entire manifold. This excludes coordinates
 in an embedded space.
 """
 function exp end
+
+@traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
+                                               GT<:Metric,
+                                               MMT<:MetricManifold{MT,GT};
+                                               !HasMetric{MT,GT}}
+    tspan = (0.0, 1.0)
+    sol = solve_exp_ode(M, x, v, tspan; dense=false, saveat=[1.0])
+    n = length(x)
+    y .= sol.u[1][n+1:end]
+    return y
+end
 
 @traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
                                                GT<:Metric,

--- a/src/forward_diff.jl
+++ b/src/forward_diff.jl
@@ -1,0 +1,14 @@
+function local_metric_jacobian(M::MetricManifold, x)
+    n = size(x, 1)
+    ∂g = reshape(ForwardDiff.jacobian(x -> local_metric(M, x), x), n, n, n)
+    return ∂g
+end
+
+function christoffel_symbols_second_jacobian(M::MetricManifold, x)
+    n = size(x, 1)
+    ∂Γ = reshape(
+        ForwardDiff.jacobian(x -> christoffel_symbols_second(M, x), x),
+        n, n, n, n
+    )
+    return ∂Γ
+end

--- a/src/ode.jl
+++ b/src/ode.jl
@@ -1,26 +1,3 @@
-@doc doc"""
-    solve_exp_ode(M::MetricManifold,
-                  x,
-                  v,
-                  tspan;
-                  solver=AutoVern9(Rodas5()),
-                  kwargs...)
-
-Approximate the exponential map on the manifold over the provided timespan
-assuming the Levi-Civita connection by solving the ordinary differential
-equation
-
-$\frac{d^2}{dt^2} x^k + \Gamma^k_{ij} \frac{d}{dt} x_i \frac{d}{dt} x_j = 0,$
-
-where $\Gamma^k_{ij}$ are the Christoffel symbols of the second kind, and
-the Einstein summation convention is assumed. The arguments `tspan` and
-`solver` follow the `OrdinaryDiffEq` conventions. `kwargs...` specify keyword
-arguments that will be passed to `OrdinaryDiffEq.solve`.
-
-Currently, the numerical integration is only accurate when using a single
-coordinate chart that covers the entire manifold. This excludes coordinates
-in an embedded space.
-"""
 function solve_exp_ode(M::MetricManifold,
                        x,
                        v,
@@ -51,27 +28,4 @@ function solve_exp_ode(M::MetricManifold,
     prob = ODEProblem(exp_problem, u0, tspan, p)
     sol = solve(prob, solver; kwargs...)
     return sol
-end
-
-@traitfn function exp(M::MMT,
-                      x,
-                      v,
-                      T::AbstractVector) where {MT<:Manifold,
-                                                GT<:Metric,
-                                                MMT<:MetricManifold{MT,GT};
-                                                !HasMetric{MT,GT}}
-    sol = solve_exp_ode(M, x, v, extrema(T); dense=false, saveat=T)
-    n = length(x)
-    return map(i -> sol.u[i][n+1:end], 1:length(T))
-end
-
-@traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
-                                               GT<:Metric,
-                                               MMT<:MetricManifold{MT,GT};
-                                               !HasMetric{MT,GT}}
-    tspan = (0.0, 1.0)
-    sol = solve_exp_ode(M, x, v, tspan; dense=false, saveat=[1.0])
-    n = length(x)
-    y .= sol.u[1][n+1:end]
-    return y
 end

--- a/src/ode.jl
+++ b/src/ode.jl
@@ -1,0 +1,77 @@
+@doc doc"""
+    solve_exp_ode(M::MetricManifold,
+                  x,
+                  v,
+                  tspan;
+                  solver=AutoVern9(Rodas5()),
+                  kwargs...)
+
+Approximate the exponential map on the manifold over the provided timespan
+assuming the Levi-Civita connection by solving the ordinary differential
+equation
+
+$\frac{d^2}{dt^2} x^k + \Gamma^k_{ij} \frac{d}{dt} x_i \frac{d}{dt} x_j = 0,$
+
+where $\Gamma^k_{ij}$ are the Christoffel symbols of the second kind, and
+the Einstein summation convention is assumed. The arguments `tspan` and
+`solver` follow the `OrdinaryDiffEq` conventions. `kwargs...` specify keyword
+arguments that will be passed to `OrdinaryDiffEq.solve`.
+
+Currently, the numerical integration is only accurate when using a single
+coordinate chart that covers the entire manifold. This excludes coordinates
+in an embedded space.
+"""
+function solve_exp_ode(M::MetricManifold,
+                       x,
+                       v,
+                       tspan;
+                       solver=AutoVern9(Rodas5()),
+                       kwargs...)
+    n = length(x)
+    iv = SVector{n}(1:n)
+    ix = SVector{n}(n+1:2n)
+    u0 = similar(x, 2n)
+    u0[iv] .= v
+    u0[ix] .= x
+
+    function exp_problem(u, p, t)
+        M = p[1]
+        dx = u[iv]
+        x = u[ix]
+        ddx = similar(u, Size(n))
+        du = similar(u)
+        Γ = christoffel_symbols_second(M, x)
+        @einsum ddx[k] = -Γ[k,i,j] * dx[i] * dx[j]
+        du[iv] .= ddx
+        du[ix] .= dx
+        return Base.convert(typeof(u), du)
+    end
+
+    p = (M,)
+    prob = ODEProblem(exp_problem, u0, tspan, p)
+    sol = solve(prob, solver; kwargs...)
+    return sol
+end
+
+@traitfn function exp(M::MMT,
+                      x,
+                      v,
+                      T::AbstractVector) where {MT<:Manifold,
+                                                GT<:Metric,
+                                                MMT<:MetricManifold{MT,GT};
+                                                !HasMetric{MT,GT}}
+    sol = solve_exp_ode(M, x, v, extrema(T); dense=false, saveat=T)
+    n = length(x)
+    return map(i -> sol.u[i][n+1:end], 1:length(T))
+end
+
+@traitfn function exp!(M::MMT, y, x, v) where {MT<:Manifold,
+                                               GT<:Metric,
+                                               MMT<:MetricManifold{MT,GT};
+                                               !HasMetric{MT,GT}}
+    tspan = (0.0, 1.0)
+    sol = solve_exp_ode(M, x, v, tspan; dense=false, saveat=[1.0])
+    n = length(x)
+    y .= sol.u[1][n+1:end]
+    return y
+end

--- a/test/metric_test.jl
+++ b/test/metric_test.jl
@@ -1,3 +1,5 @@
+using ForwardDiff, OrdinaryDiffEq
+
 include("utils.jl")
 
 struct TestEuclidean{N} <: Manifold end


### PR DESCRIPTION
As discussed in #35, by far most of `Manifold`'s long load time (>20s!) is due to `OrdinaryDiffEq` as a dependency. Since `OrdinaryDiffEq` and `ForwardDiff` are only necessary for `MetricManifold` defaults, this PR makes them optional dependencies. On my machine running Julia 1.3 rc2, `Manifold`'s new load time is ~2s.