### PR TITLE
benchmarks updated for recent changes

### DIFF
--- a/src/SymmetricPositiveDefinite.jl
+++ b/src/SymmetricPositiveDefinite.jl
@@ -359,7 +359,7 @@ end
 
 returns a orthonormal basis `Ξ` as a vector of tangent vectors (of length
 [`manifold_dimension`](@ref) of `M`) in the tangent space of `x` on the
-[`MetricManifold`](@ref of [`SymmetricPositiveDefinite`](@ref) manifold `M` with
+[`MetricManifold`](@ref) of [`SymmetricPositiveDefinite`](@ref) manifold `M` with
 [`LinearAffineMetric`](@ref) that diagonalizes the curvature tensor $R(u,v)w$
 with eigenvalues `κ` and where the direction `v` has curvature `0`.
 """


### PR DESCRIPTION
Nothing major but demonstrates that in many cases `MMatrix` is faster than `Matrix`.


```
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "2 * tv1 + 3 * tv2"]`                             | 212.000 ns (5%) |         |  480 bytes (1%) |           3 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "distance"]`                                      |   2.915 μs (5%) |         |   5.66 KiB (1%) |          21 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "exp!"]`                                          |   5.023 μs (5%) |         |   6.22 KiB (1%) |          43 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "exp"]`                                           |   5.071 μs (5%) |         |   6.38 KiB (1%) |          44 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "inner"]`                                         |   1.433 μs (5%) |         |  992 bytes (1%) |          12 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "isapprox (pt)"]`                                 | 188.000 ns (5%) |         |  160 bytes (1%) |           1 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "isapprox (tv)"]`                                 | 185.000 ns (5%) |         |  160 bytes (1%) |           1 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "log!"]`                                          |   5.156 μs (5%) |         |   5.97 KiB (1%) |          40 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "log"]`                                           |   5.205 μs (5%) |         |   6.13 KiB (1%) |          41 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "norm"]`                                          |   1.447 μs (5%) |         |  992 bytes (1%) |          12 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "similar"]`                                       |  66.000 ns (5%) |         |  160 bytes (1%) |           1 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "tv .= 2 .* tv1 .+ 3 .* tv2"]`                    |  64.000 ns (5%) |         |                 |             |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "tv = 2 * tv1 + 3 * tv2"]`                        | 214.000 ns (5%) |         |  480 bytes (1%) |           3 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type Array{Float64,2}", "tv = 2 .* tv1 .+ 3 .* tv2"]`                     | 115.000 ns (5%) |         |  160 bytes (1%) |           1 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "2 * tv1 + 3 * tv2"]`                         |  58.000 ns (5%) |         |  240 bytes (1%) |           3 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "distance"]`                                  |   2.959 μs (5%) |         |   5.97 KiB (1%) |          23 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "exp!"]`                                      |   2.108 μs (5%) |         |   3.08 KiB (1%) |          20 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "exp"]`                                       |   2.112 μs (5%) |         |   3.16 KiB (1%) |          21 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "inner"]`                                     | 905.000 ns (5%) |         |  752 bytes (1%) |           9 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "isapprox (pt)"]`                             |  68.000 ns (5%) |         |                 |             |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "isapprox (tv)"]`                             |  68.000 ns (5%) |         |                 |             |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "log!"]`                                      |   2.308 μs (5%) |         |   2.83 KiB (1%) |          17 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "log"]`                                       |   2.309 μs (5%) |         |   2.91 KiB (1%) |          18 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "norm"]`                                      | 909.000 ns (5%) |         |  752 bytes (1%) |           9 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "similar"]`                                   |  32.000 ns (5%) |         |   80 bytes (1%) |           1 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "tv .= 2 .* tv1 .+ 3 .* tv2"]`                |  40.000 ns (5%) |         |                 |             |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "tv = 2 * tv1 + 3 * tv2"]`                    |  57.000 ns (5%) |         |  240 bytes (1%) |           3 |
| `["manifolds", "SPD manifold SymmetricPositiveDef, type MArray{Tuple{3,3},Fl", "tv = 2 .* tv1 .+ 3 .* tv2"]`                 |  46.000 ns (5%) |         |   80 bytes (1%) |           1 |

```