### PR TITLE
Don't run Travis on feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
 notifications:
     email: false
 sudo: false
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/ # build tagged releases
 jobs:
   include:
     - stage: "Documentation"


### PR DESCRIPTION
Currently, Travis runs on the PR rebased onto master ("pr") and on the branch itself ("push"). The former is what appveyor does. This PR removes the latter case, effectively halving the number of Travis builds.

The pros are obvious. The downsides happen when PRs have merge conflicts that prevent the rebase; then Travis will not run, same as appveyor.