### PR TITLE
More reformatting, additional conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,58 +1,57 @@
-# Contributing to Manifolds.jl
+# Contributing to `Manifolds.jl`
 
-First off, thanks for taking the time to contribute. Any contribution is appreciated and welcome
+First, thanks for taking the time to contribute.
+Any contribution is appreciated and welcome.
 
-The following is a set of guidelines to [Manifolds.jl](https://julianlsolvers.github.io/Manifolds.jl/).
+The following is a set of guidelines to [`Manifolds.jl`](https://julianlsolvers.github.io/Manifolds.jl/).
 
 #### Table of Contents
 
-* [I just have a question](I-just-have-a-question)
-* [How can I file an issue?](how-can-I-file-an-issue)
-* [How Can I Contribute?](#how-can-I-contribute)
+* [I just have a question](#i-just-have-a-question)
+* [How can I file an issue?](#how-can-i-file-an-issue)
+* [How can I contribute?](#how-can-i-contribute)
 
 ## I just have a question
-The developers can most easily be reched either in the Julia Slack Channel [#manifolds](https://julialang.slack.com/archives/CP4QF0K5Z). You can apply for the Julia Slack [here](https://slackinvite.julialang.org) if you haven't joined yet. You can also ask your question on [discourse.julialang.org](https://discourse.julialang.org).
 
-## How Can I file an Issue?
+The developers can most easily be reached in the Julia Slack channel [#manifolds](https://julialang.slack.com/archives/CP4QF0K5Z).
+You can apply for the Julia Slack workspace [here](https://slackinvite.julialang.org) if you haven't joined yet.
+You can also ask your question on [discourse.julialang.org](https://discourse.julialang.org).
+
+## How can I file an issue?
+
 If you found a bug or want to propose a feature, we track our issues within the [GitHub repository](https://github.com/JuliaNLSolvers/Manifolds.jl/issues).
 
-## How Can I Contribute ?
+## How can I contribute?
 
 ### Add a missing method
 
-Not all methods from the our interface
-[`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html)
-have been implemented for every manifold.
-So if you notice a method missing, where you can contribute an implementation,
-even providing a single new method is a good contribution.
+Not all methods from our interface [`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html) have been implemented for every manifold.
+If you notice a method missing and can contribute an implementation, please do so!
+Even providing a single new method is a good contribution.
 
 ### Provide a new manifold
-A main contribution you can provide is another manifold, that is not yet included in the
-package. A manifold consists of  the parent type
-[`Manifold`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.Manifold)
-from [`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html).
-This package also provides the main set of functions a manifold can/should implement.
-Don't worry if you are only aware of a part of the functions. As long as the application
-you have in mind only requires a subset of these functions, implement those. The
-[`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html)
-interface provides concrete error messages for functions you might have missed.
 
-One important detail is, that the interface often provides a mutating as well as a
-non-mutating variant, see for example
-[exp!](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.exp!-Tuple{Manifold,Any,Any,Any})
-and
-[exp](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#Base.exp-Tuple{Manifold,Any,Any}).
-The non-mutating one always falls back to use the mutating one, so in most cases it should
-suffice to implement the mutating one, i.e.
-[exp!](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.exp!-Tuple{Manifold,Any,Any,Any})
-in this case.
+A main contribution you can provide is another manifold that is not yet included in the
+package.
+A manifold is a concrete type of [`Manifold`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.Manifold) from [`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html).
+This package also provides the main set of functions a manifold can/should implement.
+Don't worry if you can only implement some of the functions.
+If the application you have in mind only requires a subset of these functions, implement those.
+The [`ManifoldsBase.jl`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html) interface provides concrete error messages for the remaining unimplemented functions.
+
+One important detail is that the interface usually provides a mutating as well as a non-mutating variant
+See for example [exp!](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.exp!-Tuple{Manifold,Any,Any,Any}) and [exp](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#Base.exp-Tuple{Manifold,Any,Any}).
+The non-mutating one (e.g. `exp`) always falls back to use the mutating one, so in most cases it should
+suffice to implement the mutating one (e.g. `exp!`).
 
 Note that since the first argument is _always_ the [`Manifold`](https://julianlsolvers.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.Manifold), the mutated argument is always the second one in the signature.
 In the example we have `exp(M, x, v)` for the exponential map and `exp!(M, y, v, x)` for the mutating one, that stores the result in `y`.
 
-On the contrary the user will most likely look for the non-mutating version, when looking for help, so we recommend to add the documentation string to the non-mutating one, where all different signatures should be collected in one string. This can best be achieved by adding a docstring to the method with a general signature with the first argument being your manifold:
+On the other hand, the user will most likely look for the documentation of the non-mutating version, so we recommend adding the docstring for the non-mutating one, where all different signatures should be collected in one string when reasonable.
+This can best be achieved by adding a docstring to the method with a general signature with the first argument being your manifold:
 ````julia
     struct MyManifold <: Manifold end
+
     @doc doc"""
         exp(M::MyManifold, x, v)
 
@@ -63,11 +62,16 @@ On the contrary the user will most likely look for the non-mutating version, whe
 
 ### Code style
 
-With the documentation we try to follow the
-[documentation guidelines](https://docs.julialang.org/en/v1/manual/documentation/) from
-the Julia documentation as well as follow the
-[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle).
-It would be nice, if the `Manifold`s struct could contain a reference, where the general theory is from.
-Any implemented function should be accompanied by its mathematical formulae, if a closed form exists.
-Within the source code of one manifold, the type of the manifold should be the first element of the
-file and an alphabetical order of the functions would be preferable.
+We try to follow the [documentation guidelines](https://docs.julialang.org/en/v1/manual/documentation/) from the Julia documentation as well as [Blue Style](https://github.com/invenia/BlueStyle).
+We also run [`JuliaFormatter.jl`](https://github.com/domluna/JuliaFormatter.jl) on the source code, which enforces a number of conventions consistent with Blue Style.
+We also follow a few internal conventions:
+- It is preferred that the `Manifold`'s struct contain a reference to the general theory.
+- Any implemented function should be accompanied by its mathematical formulae if a closed form exists.
+- Within the source code of one manifold, the type of the manifold should be the first element of the file, and an alphabetical order of the functions is preferable.
+- The above implies that the mutating variant of a function follows the non-mutating variant.
+- There should be no dangling `=` signs.
+  If a "one-line" function is too long to fit in a line, then make it multiline.
+- Always add a newline between things of different types (struct/method/const)
+- Always add a newline between methods for different functions (including mutating/nonmutating variants)
+- Prefer to have no newline between methods for the same function; when reasonable, merge the docstrings.
+- All `import`/`using`/`include` should be in the main module file.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,17 +10,17 @@ makedocs(
         "ManifoldsBase.jl" => "interface.md",
         "Manifolds" => [
             "Basic manifolds" => [
-                "Cholesky Space" => "manifolds/choleskyspace.md",
+                "Cholesky space" => "manifolds/choleskyspace.md",
                 "Circle" => "manifolds/circle.md",
                 "Euclidean" => "manifolds/euclidean.md",
-                "Fixed Rank Matrices" => "manifolds/fixedrankmatrices.md",
+                "Fixed-rank matrices" => "manifolds/fixedrankmatrices.md",
                 "Grassmannian" => "manifolds/grassmann.md",
-                "Hyperbolic Space" => "manifolds/hyperbolic.md",
+                "Hyperbolic space" => "manifolds/hyperbolic.md",
                 "Rotations" => "manifolds/rotations.md",
                 "Sphere" => "manifolds/sphere.md",
                 "Stiefel" => "manifolds/stiefel.md",
-                "Symmetric Matrices" => "manifolds/symmetric.md",
-                "Symmetric Positive Definite" => "manifolds/symmetricpositivedefinite.md"
+                "Symmetric matrices" => "manifolds/symmetric.md",
+                "Symmetric positive definite" => "manifolds/symmetricpositivedefinite.md"
             ],
             "Combined manifolds" => [
                 "Power manifold" => "manifolds/power.md",
@@ -37,10 +37,10 @@ makedocs(
         "Distributions" => "distributions.md",
         "Orthonormal bases" => "orthonormal_bases.md",
         "Library" => [
-            "Numbers" => "lib/numbers.md",
+            "Number systems" => "lib/numbers.md",
             "Public" => "lib/public.md",
             "Internals" => "lib/internals.md",
-            "Automatic Differentiation" => "lib/autodiff.md"
+            "Automatic differentiation" => "lib/autodiff.md"
         ]
     ]
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,7 @@ makedocs(
                 "Torus" => "manifolds/torus.md"
             ],
             "Combined manifolds" => [
-                "Graph Manifold" => "manifolds/graph.md",
+                "Graph manifold" => "manifolds/graph.md",
                 "Power manifold" => "manifolds/power.md",
                 "Product manifold" => "manifolds/product.md",
                 "Vector bundle" => "manifolds/vector_bundle.md"

--- a/docs/src/distributions.md
+++ b/docs/src/distributions.md
@@ -7,6 +7,7 @@ Modules = [Manifolds]
 Pages = ["distributions.jl"]
 Order = [:type, :function]
 ```
+
 ```@docs
 Manifolds.ProjectedPointDistribution
 Manifolds.ProjectedFVectorDistribution

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,6 @@
 # Manifolds
 
-Package __Manifolds__ aims to provide both a unified interface to define and
-use manifolds as well as a library of manifolds to use for your projects.
+The package __Manifolds__ aims to provide both a unified interface to define and use manifolds as well as a library of manifolds to use for your projects.
 
 ```@autodocs
 Modules = [Manifolds, ManifoldsBase]

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -1,14 +1,11 @@
-# ManifoldsBase.jl – An Interface for Manifolds
+# `ManifoldsBase.jl` – an interface for manifolds
 
-The interface for a manifold is provided in the lightweight package
-[`ManifoldsBase.jl](https://github.com/JuliaNLSolvers/ManifoldsBase.jl) separate
-from the collection of manifolds in here. You can easily implement your algorithms
-and even first own manifolds just using the interface.
+The interface for a manifold is provided in the lightweight package [`ManifoldsBase.jl](https://github.com/JuliaNLSolvers/ManifoldsBase.jl) separate
+from the collection of manifolds in here.
+You can easily implement your algorithms and even your own manifolds just using the interface.
 
 The following functions are currently available from the interface.
-If a manifold that you implement for your own package fits this interface,
-we happily look forward to a
-[Pull Request](https://github.com/JuliaNLSolvers/Manifolds.jl/compare) to add it here.
+If a manifold that you implement for your own package fits this interface, we happily look forward to a [Pull Request](https://github.com/JuliaNLSolvers/Manifolds.jl/compare) to add it here.
 
 ```@autodocs
 Modules = [Manifolds, ManifoldsBase]
@@ -17,6 +14,7 @@ Order = [:type, :function]
 ```
 
 `DefaultManifold` is a simplified version of [`Euclidean`](@ref) and demonstrates a basic interface implementation.
+
 ```@docs
 ManifoldsBase.DefaultManifold
 ```

--- a/docs/src/lib/autodiff.md
+++ b/docs/src/lib/autodiff.md
@@ -1,7 +1,6 @@
-# Automatic Differentiation
+# Automatic differentiation
 
-Documentation for `Manifolds.jl`'s methods and types for automatic
-differentiation.
+Documentation for `Manifolds.jl`'s methods and types for automatic differentiation.
 
 ```@docs
 Manifolds.adbackend

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -1,4 +1,4 @@
-# Internal Documentation
+# Internal documentation
 
 Documentation for `Manifolds.jl`'s internal methods and types.
 

--- a/docs/src/lib/numbers.md
+++ b/docs/src/lib/numbers.md
@@ -1,4 +1,4 @@
-# Numbers
+# Number systems
 
 ```@docs
 Manifolds.AbstractNumbers

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -1,4 +1,4 @@
-# Public Documentation
+# Public documentation
 
 Documentation for `Manifolds.jl`'s public interface.
 

--- a/docs/src/manifolds/choleskyspace.md
+++ b/docs/src/manifolds/choleskyspace.md
@@ -1,6 +1,6 @@
-# Cholesky Space
+# Cholesky space
 
-The Cholesky Space is a Riemannian manifold on the lower triangular matrices.
+The Cholesky space is a Riemannian manifold on the lower triangular matrices.
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/euclidean.md
+++ b/docs/src/manifolds/euclidean.md
@@ -1,16 +1,9 @@
-# Euclidean Space
+# Euclidean space
 
-The Euclidean space $\mathbb R^n$ is a simple model space, since it has
-curvature constantly zero everywhere and hence nearly all operations simplify.
-
-```@autodocs
-Modules = [Manifolds]
-Pages = ["manifolds/Euclidean.jl"]
-Order = [:type]
-```
+The Euclidean space $\mathbb R^n$ is a simple model space, since it has curvature constantly zero everywhere; hence, nearly all operations simplify.
 
 ```@autodocs
 Modules = [Manifolds]
 Pages = ["manifolds/Euclidean.jl"]
-Order = [:function]
+Order = [:type,:function]
 ```

--- a/docs/src/manifolds/fixedrankmatrices.md
+++ b/docs/src/manifolds/fixedrankmatrices.md
@@ -1,4 +1,4 @@
-# Fixed Rank Matrices
+# Fixed-rank matrices
 
 ```@autodocs
 Modules = [Manifolds]
@@ -6,4 +6,4 @@ Pages = ["FixedRankMatrices.jl"]
 Order = [:type, :function]
 ```
 
-# Literature
+## Literature

--- a/docs/src/manifolds/graph.md
+++ b/docs/src/manifolds/graph.md
@@ -1,9 +1,7 @@
-# The Graph Manifold
+# Graph manifold
 
-For a given graph $G(V,E)$ implemented using [`LightGraphs.jl`](https://juliagraphs.github.io/LightGraphs.jl/latest/)
-the [`GraphManifold`](@ref) models a [`PowerManifold`](@ref) either on the nodes or edges of the graph, depending on the
-[`GraphManifoldType`](@ref), i.e. it's either a $\mathcal M^{\lvert V \rvert}$ for the case of a vertex manifold and a
-$\mathcal M^{\lvert E \rvert}$ for the case of a edge manifold.
+For a given graph $G(V,E)$ implemented using [`LightGraphs.jl`](https://juliagraphs.github.io/LightGraphs.jl/latest/), the [`GraphManifold`](@ref) models a [`PowerManifold`](@ref) either on the nodes or edges of the graph, depending on the [`GraphManifoldType`](@ref).
+i.e., it's either a $\mathcal M^{\lvert V \rvert}$ for the case of a vertex manifold or a $\mathcal M^{\lvert E \rvert}$ for the case of a edge manifold.
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/grassmann.md
+++ b/docs/src/manifolds/grassmann.md
@@ -1,13 +1,7 @@
-# Grassmann Manifold
+# Grassmann manifold
 
 ```@autodocs
 Modules = [Manifolds]
 Pages = ["manifolds/Grassmann.jl"]
-Order = [:type]
-```
-
-```@autodocs
-Modules = [Manifolds]
-Pages = ["manifolds/Grassmann.jl"]
-Order = [:function]
+Order = [:type,:function]
 ```

--- a/docs/src/manifolds/hyperbolic.md
+++ b/docs/src/manifolds/hyperbolic.md
@@ -1,5 +1,5 @@
-# Hyperbolic Space
--
+# Hyperbolic space
+
 ```@autodocs
 Modules = [Manifolds]
 Pages = ["manifolds/Hyperbolic.jl"]

--- a/docs/src/manifolds/metric.md
+++ b/docs/src/manifolds/metric.md
@@ -2,17 +2,14 @@
 
 A Riemannian manifold always consists of a [topological manifold](https://en.wikipedia.org/wiki/Topological_manifold) together with a smoothly varying metric $g$.
 
-However, often there is an implicitly assumed (default) metric, like the usual
-inner product on [`Euclidean`](@ref) space. This decorator takes this into
-account. It is not necessary to use this decorator if you implement just one (or
-the first) metric. If you later introduce a second, the old (first) metric can
-be used with the (non [`MetricManifold`](@ref)) [`Manifold`](@ref), i.e.
-without an explicitly stated metric. The decorator acts transparent in that
-sense; see [`is_decorator_manifold`](@ref) for details.
+However, often there is an implicitly assumed (default) metric, like the usual inner product on [`Euclidean`](@ref) space.
+This decorator takes this into account.
+It is not necessary to use this decorator if you implement just one (or the first) metric.
+If you later introduce a second, the old (first) metric can be used with the (non [`MetricManifold`](@ref)) [`Manifold`](@ref), i.e. without an explicitly stated metric.
+The decorator acts transparent in that sense; see [`is_decorator_manifold`](@ref) for details.
 
-This manifold decorator serves two purposes: to implement different metrics
-(e.g. in closed form) for one [`Manifold`](@ref) and to provide a way to compute
-geodesics on manifolds, where this [`Metric`](@ref) does not yield closed formula. 
+This manifold decorator serves two purposes:
+1. to implement different metrics (e.g. in closed form) for one [`Manifold`](@ref) 2. to provide a way to compute geodesics on manifolds, where this [`Metric`](@ref) does not yield closed formula.
 
 Let's first look at the provided types.
 
@@ -26,24 +23,15 @@ Order = [:type]
 
 ## Implement Different Metrics on the same Manifold
 
-In order to distinguish different metrics on one manifold, one can introduce
-two [`Metric`](@ref)s and use this type to dispatch on the metric, see 
-[`SymmetricPositiveDefinite`](@ref). To avoid overhead, one [`Metric`](@ref)
-can then be marked as being the default, i.e. the one that is used, when no
-[`MetricManifold`](@ref) decorator is present. This avoids reimplementation of
-the first existing metric, access to the metric-dependent functions that were
-implemented using the undecorated manifold, as well as the transparent fallback
-of the corresponding [`MetricManifold`](@ref) with default metric to the
-undecorated implementations. This does not cause any runtime overhead. Introducing
-a default [`Metric`](@ref) serves a better readability of the code when working
-with different metrics.
+In order to distinguish different metrics on one manifold, one can introduce two [`Metric`](@ref)s and use this type to dispatch on the metric, see [`SymmetricPositiveDefinite`](@ref).
+To avoid overhead, one [`Metric`](@ref) can then be marked as being the default, i.e. the one that is used, when no [`MetricManifold`](@ref) decorator is present.
+This avoids reimplementation of the first existing metric, access to the metric-dependent functions that were implemented using the undecorated manifold, as well as the transparent fallback of the corresponding [`MetricManifold`](@ref) with default metric to the undecorated implementations.
+This does not cause any runtime overhead.
+Introducing a default [`Metric`](@ref) serves a better readability of the code when working with different metrics.
 
 ## Implementation of Metrics
 
-For the case that a [`local_metric`](@ref) is implemented as a bilinear form
-that is positive definite, the following further functions are provided,
-unless the corresponding [`Metric`](@ref) is marked as default – then the fallbacks
-mentioned in the last section are used for e.g. the [`exp!`](@ref)onential map.
+For the case that a [`local_metric`](@ref) is implemented as a bilinear form that is positive definite, the following further functions are provided, unless the corresponding [`Metric`](@ref) is marked as default – then the fallbacks mentioned in the last section are used for e.g. the [`exp!`](@ref)onential map.
 
 ```@autodocs
 Modules = [Manifolds, ManifoldsBase]

--- a/docs/src/manifolds/power.md
+++ b/docs/src/manifolds/power.md
@@ -1,4 +1,4 @@
-# Product Manifold
+# Product manifold
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/product.md
+++ b/docs/src/manifolds/product.md
@@ -1,6 +1,7 @@
-# Product Manifold
+# Product manifold
 
-Product manifold $M = M_1 \times M_2 \times \dots M_n$ of manifolds $M_1, M_2, \dots, M_n$. Points on the product manifold can be constructed using [`ProductRepr`](@ref) with canonical projections $\Pi_i \colon M \to M_i$ for $i \in 1, 2, \dots, n$ provided by [`submanifold_component`](@ref).
+Product manifold $M = M_1 \times M_2 \times \dots M_n$ of manifolds $M_1, M_2, \dots, M_n$.
+Points on the product manifold can be constructed using [`ProductRepr`](@ref) with canonical projections $\Pi_i \colon M \to M_i$ for $i \in 1, 2, \dots, n$ provided by [`submanifold_component`](@ref).
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/rotations.md
+++ b/docs/src/manifolds/rotations.md
@@ -5,7 +5,8 @@ The manifold $\mathrm{SO}(n)$ of orthogonal matrices with determinant $+1$ in $\
 $\mathrm{SO}(n) = \bigl\{R \in \mathbb{R}^{n\times n} \big| RR^{\mathrm{T}} =
 R^{\mathrm{T}}R = \mathrm{I}_n, \det(R) = 1 \bigr\}$
 
-``\mathrm{SO}(n)`` is a subgroup of the orthogonal group $\mathrm{O}(n)$ and also known as the special orthogonal group or the set of rotations group.
+The Lie group $\mathrm{SO}(n)$ is a subgroup of the orthogonal group $\mathrm{O}(n)$ and also known as the special orthogonal group or the set of rotations group.
+See also [`SpecialOrthogonal`](@ref), which is this manifold equipped with the group operation.
 
 Tangent vectors are represented by elements of the corresponding Lie algebra, which is the tangent space at the identity element.
 This convention allows for more efficient operations on tangent vectors.

--- a/docs/src/manifolds/rotations.md
+++ b/docs/src/manifolds/rotations.md
@@ -5,11 +5,16 @@ The manifold $\mathrm{SO}(n)$ of orthogonal matrices with determinant $+1$ in $\
 $\mathrm{SO}(n) = \bigl\{R \in \mathbb{R}^{n\times n} \big| RR^{\mathrm{T}} =
 R^{\mathrm{T}}R = \mathrm{I}_n, \det(R) = 1 \bigr\}$
 
- $\mathrm{SO}(n)$ is a subgroup of the orthogonal group $\mathrm{O}(n)$ and also known as the special orthogonal group or the set of rotations group.
+``\mathrm{SO}(n)`` is a subgroup of the orthogonal group $\mathrm{O}(n)$ and also known as the special orthogonal group or the set of rotations group.
 
-Tangent vectors are represented by elements of the corresponding Lie algebra, which is the tangent space at the identity element. This convention allows for more efficient operations on tangent vectors. Tangent spaces at different points are different vector spaces.
+Tangent vectors are represented by elements of the corresponding Lie algebra, which is the tangent space at the identity element.
+This convention allows for more efficient operations on tangent vectors.
+Tangent spaces at different points are different vector spaces.
 
-Let $L_R\colon \mathrm{SO}(n) \to \mathrm{SO}(n)$ where $R \in \mathrm{SO}(n)$ be the left-multiplication by $R$, that is $L_R(S) = RS$. The tangent space at rotation $R$, $T_R \mathrm{SO}(n)$, is related to the tangent space at the identity rotation $\mathrm{I}_n$ by the differential of $L_R$ at identity, $(\mathrm{d}L_R)_{\mathrm{I}_n} \colon T_{\mathrm{I}_n} \mathrm{SO}(n) \to T_R \mathrm{SO}(n)$. For a tangent vector at the identity rotation $v \in T_{\mathrm{I}_n} \mathrm{SO}(n)$ the matrix representation of the corresponding tangent vector $w$ at a rotation $R$ can be obtained by matrix multiplication: $w=Rv \in T_R \mathrm{SO}(n)$. You can compare the functions [`log!(::Manifolds.Rotations, v, x, y)`](@ref) and [`exp!(::Manifolds.Rotations, y, x, v)`](@ref) to see how it works in practice.
+Let $L_R\colon \mathrm{SO}(n) \to \mathrm{SO}(n)$ where $R \in \mathrm{SO}(n)$ be the left-multiplication by $R$, that is $L_R(S) = RS$.
+The tangent space at rotation $R$, $T_R \mathrm{SO}(n)$, is related to the tangent space at the identity rotation $\mathrm{I}_n$ by the differential of $L_R$ at identity, $(\mathrm{d}L_R)_{\mathrm{I}_n} \colon T_{\mathrm{I}_n} \mathrm{SO}(n) \to T_R \mathrm{SO}(n)$.
+For a tangent vector at the identity rotation $v \in T_{\mathrm{I}_n} \mathrm{SO}(n)$ the matrix representation of the corresponding tangent vector $w$ at a rotation $R$ can be obtained by matrix multiplication: $w=Rv \in T_R \mathrm{SO}(n)$.
+You can compare the functions [`log!(::Manifolds.Rotations, v, x, y)`](@ref) and [`exp!(::Manifolds.Rotations, y, x, v)`](@ref) to see how it works in practice.
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/symmetric.md
+++ b/docs/src/manifolds/symmetric.md
@@ -1,6 +1,5 @@
 # Symmetric matrices
 
-
 ```@autodocs
 Modules = [Manifolds]
 Pages = ["manifolds/Symmetric.jl"]

--- a/docs/src/manifolds/symmetricpositivedefinite.md
+++ b/docs/src/manifolds/symmetricpositivedefinite.md
@@ -1,4 +1,4 @@
-# Symmetric Positive Definite Matrices
+# Symmetric positive definite matrices
 
 The symmetric positive definite matrices
 
@@ -10,9 +10,7 @@ The symmetric positive definite matrices
 SymmetricPositiveDefinite
 ```
 
-can -- for example -- be illustrated as ellipsoids:  since the eigen values are all positive
-they can be taken as lengths of the axes of an ellipsoids while the directions are given by
-the eigenvectors.
+can -- for example -- be illustrated as ellipsoids:  since the eigen values are all positive they can be taken as lengths of the axes of an ellipsoids while the directions are given by the eigenvectors.
 
 ![An example set of data](../assets/images/SPDSignal.png)
 
@@ -29,17 +27,13 @@ Order = [:function]
 
 ## Default Metric: Linear Affine Metric
 
-
 ```@autodocs
 Modules = [Manifolds]
 Pages = ["manifolds/SymmetricPositiveDefiniteLinearAffine.jl"]
 Order = [:type]
 ```
 
-This metric is also the default metric, i.e.
-any call of the following functions with
-`P=SymmetricPositiveDefinite(3)` will result in
-`MetricManifold(P,LinearAffineMetric())`and hence yield the formulae described in this seciton.
+This metric is also the default metric, i.e. any call of the following functions with `P=SymmetricPositiveDefinite(3)` will result in `MetricManifold(P,LinearAffineMetric())`and hence yield the formulae described in this seciton.
 
 ```@autodocs
 Modules = [Manifolds]

--- a/docs/src/manifolds/vector_bundle.md
+++ b/docs/src/manifolds/vector_bundle.md
@@ -1,17 +1,24 @@
 # Vector bundles
 
-Vector bundle $E$ is a manifold that is built on top of another manifold $M$ (base space). It is characterized by a continuous function $\Pi \colon E \to M$, such that for each point $x \in M$ the preimage of $x$ by $\Pi$, $\Pi^{-1}(\{x\})$, has a structure of a vector space. These vector spaces are called fibers. Bundle projection can be performed using function [`bundle_projection`](@ref).
+Vector bundle $E$ is a manifold that is built on top of another manifold $M$ (base space).
+It is characterized by a continuous function $\Pi \colon E \to M$, such that for each point $x \in M$ the preimage of $x$ by $\Pi$, $\Pi^{-1}(\{x\})$, has a structure of a vector space.
+These vector spaces are called fibers.
+Bundle projection can be performed using function [`bundle_projection`](@ref).
 
-Tangent bundle is a simple example of a vector bundle, swhere each fiber is the tangent space at the specified point $x$. An object representing a tangent bundle can be obtained using the constructor called `TangentBundle`.
+Tangent bundle is a simple example of a vector bundle, where each fiber is the tangent space at the specified point $x$.
+An object representing a tangent bundle can be obtained using the constructor called `TangentBundle`.
 
 Fibers of a vector bundle are represented by the type `VectorBundleFibers`.
 The important difference between functions operating on `VectorBundle` and `VectorBundleFibers` is that in the first case both a point on the underlying manifold and the vector are represented together (by a single argument) while in the second case only the vector part is present, while the point is supplied in a different argument where needed.
 
-`VectorBundleFibers` refers to the whole set of fibers of a vector bundle. There is also another type, [`VectorSpaceAtPoint`](@ref), that represents a specific fiber at a given point. This distinction is made to reduce the need to repeatedly construct objects of type [`VectorSpaceAtPoint`](@ref) in certain usage scenarios.
+`VectorBundleFibers` refers to the whole set of fibers of a vector bundle.
+There is also another type, [`VectorSpaceAtPoint`](@ref), that represents a specific fiber at a given point.
+This distinction is made to reduce the need to repeatedly construct objects of type [`VectorSpaceAtPoint`](@ref) in certain usage scenarios.
 
 ## FVector
 
-For cases where confusion between different types of vectors is possible, the type [`FVector`](@ref) can be used to express which type of vector space the vector belongs to. It is used for example in musical isomorphisms (the [`flat`](@ref) and [`sharp`](@ref) functions) that are used to go from a tangent space to cotangent space and vice versa.
+For cases where confusion between different types of vectors is possible, the type [`FVector`](@ref) can be used to express which type of vector space the vector belongs to.
+It is used for example in musical isomorphisms (the [`flat`](@ref) and [`sharp`](@ref) functions) that are used to go from a tangent space to cotangent space and vice versa.
 
 ```@autodocs
 Modules = [Manifolds, ManifoldsBase]

--- a/docs/src/orthonormal_bases.md
+++ b/docs/src/orthonormal_bases.md
@@ -13,10 +13,10 @@ The main types are:
   [`ArbitraryOrthonormalBasis`](@ref) doesn't require precomputing but [`DiagonalizingOrthonormalBasis`](@ref) and [`DiagonalizingOrthonormalBasis`](@ref) usually do.
 
 The main functions are:
-* [`basis`](@ref) precomputes basis at a certain point.
+* [`get_basis`](@ref) precomputes a basis at a certain point.
 * [`get_coordinates`](@ref) returns coordinates of a tangent vector.
-* [`get_vector`](@ref) returns vector for specified coordinates.
-* [`vectors`](@ref) returns a vector of basis vectors (calling it should be avoided for high-dimensional manifolds).
+* [`get_vector`](@ref) returns a vector for the specified coordinates.
+* [`get_vectors`](@ref) returns a vector of basis vectors (calling it should be avoided for high-dimensional manifolds).
 
 ```@autodocs
 Modules = [Manifolds]

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -1,12 +1,14 @@
 module Manifolds
 
 import Base:
+    Array,
     +,
     -,
     *,
     \,
     /,
     ^,
+    ==,
     angle,
     axes,
     convert,
@@ -24,6 +26,7 @@ import Base:
     one,
     promote_rule,
     setindex!,
+    similar,
     show,
     similar,
     size,
@@ -74,6 +77,7 @@ import Random: rand
 import Statistics: mean, mean!, median, median!, std, var
 import StatsBase: kurtosis, mean_and_std, mean_and_var, moment, skewness
 
+using Distributions
 using Einsum: @einsum
 using FiniteDifferences
 using HybridArrays
@@ -89,6 +93,7 @@ using Markdown: @doc_str
 using Random: AbstractRNG
 using Requires
 using StaticArrays
+using StatsBase: AbstractWeights
 using UnsafeArrays
 
 """

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -1,8 +1,34 @@
 module Manifolds
 
-import Base: +, -, *, \, /, ^, angle, axes, convert, copy, copyto!, dataids, eltype, exp,
-    getindex, identity, inv, isapprox, length, log, one, promote_rule, setindex!, show,
-    similar, size, transpose, zero
+import Base:
+    +,
+    -,
+    *,
+    \,
+    /,
+    ^,
+    angle,
+    axes,
+    convert,
+    copy,
+    copyto!,
+    dataids,
+    eltype,
+    exp,
+    getindex,
+    identity,
+    inv,
+    isapprox,
+    length,
+    log,
+    one,
+    promote_rule,
+    setindex!,
+    show,
+    similar,
+    size,
+    transpose,
+    zero
 import Distributions: _rand!, support
 import LinearAlgebra: cross, det, Diagonal, dot, mul!, norm, I, UniformScaling
 import ManifoldsBase: array_value, base_manifold, check_manifold_point, check_tangent_vector
@@ -10,9 +36,20 @@ import ManifoldsBase: distance, exp, exp!, geodesic, injectivity_radius, inner
 import ManifoldsBase: isapprox, is_manifold_point, is_tangent_vector, is_decorator_manifold
 import ManifoldsBase: inverse_retract, inverse_retract!, log, log!, manifold_dimension, norm
 import ManifoldsBase: project_point, project_point!, project_tangent, project_tangent!
-import ManifoldsBase: representation_size, retract, retract!, similar_result, similar_result_type, shortest_geodesic
-import ManifoldsBase: vector_transport_along, vector_transport_along!, vector_transport_direction,
-    vector_transport_direction!, vector_transport_to, vector_transport_to!
+import ManifoldsBase:
+    representation_size,
+    retract,
+    retract!,
+    similar_result,
+    similar_result_type,
+    shortest_geodesic
+import ManifoldsBase:
+    vector_transport_along,
+    vector_transport_along!,
+    vector_transport_direction,
+    vector_transport_direction!,
+    vector_transport_to,
+    vector_transport_to!
 import ManifoldsBase: zero_tangent_vector, zero_tangent_vector!
 import Random: rand
 import Statistics: mean, mean!, median, median!, std, var
@@ -24,7 +61,8 @@ using HybridArrays
 using LinearAlgebra
 using Base.Iterators: repeated
 using ManifoldsBase: CoTVector, Manifold, MPoint, TVector
-using ManifoldsBase: ArrayCoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
+using ManifoldsBase:
+    ArrayCoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
 using ManifoldsBase: AbstractRetractionMethod, ExponentialRetraction
 using ManifoldsBase: AbstractInverseRetractionMethod, LogarithmicInverseRetraction
 using ManifoldsBase: AbstractVectorTransportMethod, ParallelTransport, ProjectionTransport
@@ -196,68 +234,202 @@ include("groups/special_euclidean.jl")
 include("statistics.jl")
 
 function __init__()
-    @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
+    @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" begin
         using .ForwardDiff
         include("forward_diff.jl")
     end
 
-    @require OrdinaryDiffEq="1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
+    @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
         using .OrdinaryDiffEq: ODEProblem, AutoVern9, Rodas5, solve
         include("ode.jl")
     end
 end
 #
 export CoTVector, Manifold, MPoint, TVector, Manifold
-export Euclidean, CholeskySpace, Circle, FixedRankMatrices, Grassmann,
-    Hyperbolic, Rotations,Sphere, Stiefel, SymmetricMatrices, SymmetricPositiveDefinite
+export Euclidean,
+    CholeskySpace,
+    Circle,
+    FixedRankMatrices,
+    Grassmann,
+    Hyperbolic,
+    Rotations,
+    Sphere,
+    Stiefel,
+    SymmetricMatrices,
+    SymmetricPositiveDefinite
 export SVDMPoint, UMVTVector, AbstractNumbers, ℝ, ℂ, ℍ
 # decorator manifolds
 export ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
-export CotangentBundle, CotangentSpaceAtPoint, CotangentBundleFibers, CotangentSpace, FVector
+export CotangentBundle,
+    CotangentSpaceAtPoint, CotangentBundleFibers, CotangentSpace, FVector
 export PowerManifold, ProductManifold
 export ProjectedPointDistribution, ProductRepr, TangentBundle, TangentBundleFibers
 export TangentSpace, TangentSpaceAtPoint, VectorSpaceAtPoint, VectorSpaceType, VectorBundle
 export VectorBundleFibers
 export AbstractVectorTransportMethod, ParallelTransport, ProjectedPointDistribution
-export Metric, RiemannianMetric, LorentzMetric, MinkowskiMetric, EuclideanMetric, MetricManifold,
-    LinearAffineMetric, LogEuclideanMetric, LogCholeskyMetric, PowerMetric, ProductMetric
+export Metric,
+    RiemannianMetric,
+    LorentzMetric,
+    MinkowskiMetric,
+    EuclideanMetric,
+    MetricManifold,
+    LinearAffineMetric,
+    LogEuclideanMetric,
+    LogCholeskyMetric,
+    PowerMetric,
+    ProductMetric
 export AbstractVectorTransportMethod, ParallelTransport, ProjectionTransport
 export AbstractRetractionMethod, QRRetraction, PolarRetraction, ProjectionRetraction
-export AbstractInverseRetractionMethod, QRInverseRetraction, PolarInverseRetraction,
-    ProjectionInverseRetraction
-export AbstractEstimationMethod, GradientDescentEstimation, CyclicProximalPointEstimation,
-    GeodesicInterpolation, GeodesicInterpolationWithinRadius
-export base_manifold, bundle_projection, christoffel_symbols_first, christoffel_symbols_second,
-    christoffel_symbols_second_jacobian, complex_dot, det_local_metric, distance,
-    einstein_tensor, exp, exp!, flat, flat!, gaussian_curvature, geodesic, hat, hat!,
-    injectivity_radius, inner, inverse_local_metric, inverse_retract, inverse_retract!,
-    isapprox, is_decorator_manifold, is_default_metric, is_manifold_point,
-    is_tangent_vector, isapprox, inner, kurtosis, local_metric, local_metric_jacobian, log,
-    log!, log_local_metric_density, manifold_dimension, metric, mean, mean!, mean_and_var,
-    mean_and_std, median, median!, moment, norm, normal_tvector_distribution, one,
-    project_point, project_point!, project_tangent, project_tangent!,
-    projected_distribution, real_dimension, ricci_curvature, ricci_tensor,
-    representation_size, retract, retract!, riemann_tensor, sharp, sharp!,
-    shortest_geodesic, similar_result, skewness, std, sym_rem, submanifold,
-    submanifold_component, submanifold_components, var, vector_space_dimension,
-    vector_transport_along, vector_transport_along!, vector_transport_direction,
-    vector_transport_direction!, vector_transport_to, vector_transport_to!, vee, vee!,
-    zero_vector, zero_vector!, zero_tangent_vector, zero_tangent_vector!, ×
+export AbstractInverseRetractionMethod,
+    QRInverseRetraction, PolarInverseRetraction, ProjectionInverseRetraction
+export AbstractEstimationMethod,
+    GradientDescentEstimation,
+    CyclicProximalPointEstimation,
+    GeodesicInterpolation,
+    GeodesicInterpolationWithinRadius
+export base_manifold,
+    bundle_projection,
+    christoffel_symbols_first,
+    christoffel_symbols_second,
+    christoffel_symbols_second_jacobian,
+    complex_dot,
+    det_local_metric,
+    distance,
+    einstein_tensor,
+    exp,
+    exp!,
+    flat,
+    flat!,
+    gaussian_curvature,
+    geodesic,
+    hat,
+    hat!,
+    injectivity_radius,
+    inner,
+    inverse_local_metric,
+    inverse_retract,
+    inverse_retract!,
+    isapprox,
+    is_decorator_manifold,
+    is_default_metric,
+    is_manifold_point,
+    is_tangent_vector,
+    isapprox,
+    inner,
+    kurtosis,
+    local_metric,
+    local_metric_jacobian,
+    log,
+    log!,
+    log_local_metric_density,
+    manifold_dimension,
+    metric,
+    mean,
+    mean!,
+    mean_and_var,
+    mean_and_std,
+    median,
+    median!,
+    moment,
+    norm,
+    normal_tvector_distribution,
+    one,
+    project_point,
+    project_point!,
+    project_tangent,
+    project_tangent!,
+    projected_distribution,
+    real_dimension,
+    ricci_curvature,
+    ricci_tensor,
+    representation_size,
+    retract,
+    retract!,
+    riemann_tensor,
+    sharp,
+    sharp!,
+    shortest_geodesic,
+    similar_result,
+    skewness,
+    std,
+    sym_rem,
+    submanifold,
+    submanifold_component,
+    submanifold_components,
+    var,
+    vector_space_dimension,
+    vector_transport_along,
+    vector_transport_along!,
+    vector_transport_direction,
+    vector_transport_direction!,
+    vector_transport_to,
+    vector_transport_to!,
+    vee,
+    vee!,
+    zero_vector,
+    zero_vector!,
+    zero_tangent_vector,
+    zero_tangent_vector!,
+    ×
 # Lie group types & functions
-export AbstractGroupAction, AbstractGroupOperation, AbstractGroupManifold, ActionDirection,
-    AdditionOperation, CircleGroup, MultiplicationOperation, GroupManifold, GroupOperationAction,
-    Identity, LeftAction, ProductGroup, ProductOperation, RightAction, RotationAction, SemidirectProductGroup,
-    SpecialEuclidean, SpecialOrthogonal, TranslationGroup, TranslationAction
-export apply, apply!, apply_diff, apply_diff!, base_group, center_of_orbit, compose,
-    compose!, direction, g_manifold, identity, identity!, inv, inv!, inverse_apply,
-    inverse_apply!, inverse_apply_diff, inverse_apply_diff!, inverse_translate,
-    inverse_translate!, inverse_translate_diff, inverse_translate_diff!, optimal_alignment,
-    optimal_alignment!, switch_direction, translate, translate!, translate_diff,
+export AbstractGroupAction,
+    AbstractGroupOperation,
+    AbstractGroupManifold,
+    ActionDirection,
+    AdditionOperation,
+    CircleGroup,
+    MultiplicationOperation,
+    GroupManifold,
+    GroupOperationAction,
+    Identity,
+    LeftAction,
+    ProductGroup,
+    ProductOperation,
+    RightAction,
+    RotationAction,
+    SemidirectProductGroup,
+    SpecialEuclidean,
+    SpecialOrthogonal,
+    TranslationGroup,
+    TranslationAction
+export apply,
+    apply!,
+    apply_diff,
+    apply_diff!,
+    base_group,
+    center_of_orbit,
+    compose,
+    compose!,
+    direction,
+    g_manifold,
+    identity,
+    identity!,
+    inv,
+    inv!,
+    inverse_apply,
+    inverse_apply!,
+    inverse_apply_diff,
+    inverse_apply_diff!,
+    inverse_translate,
+    inverse_translate!,
+    inverse_translate_diff,
+    inverse_translate_diff!,
+    optimal_alignment,
+    optimal_alignment!,
+    switch_direction,
+    translate,
+    translate!,
+    translate_diff,
     translate_diff!
 # Orthonormal bases
-export AbstractBasis, AbstractOrthonormalBasis, AbstractPrecomputedOrthonormalBasis,
-    ArbitraryOrthonormalBasis, DiagonalizingOrthonormalBasis,
-    PrecomputedDiagonalizingOrthonormalBasis, PrecomputedOrthonormalBasis,
-    PrecomputedProductOrthonormalBasis, ProjectedOrthonormalBasis
+export AbstractBasis,
+    AbstractOrthonormalBasis,
+    AbstractPrecomputedOrthonormalBasis,
+    ArbitraryOrthonormalBasis,
+    DiagonalizingOrthonormalBasis,
+    PrecomputedDiagonalizingOrthonormalBasis,
+    PrecomputedOrthonormalBasis,
+    PrecomputedProductOrthonormalBasis,
+    ProjectedOrthonormalBasis
 export get_basis, get_coordinates, get_vector, get_vectors, number_system
 end # module

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -120,8 +120,7 @@ inverse.
 """
 function hat(M::Manifold, x, vⁱ)
     v = similar_result(M, hat, x, vⁱ)
-    hat!(M, v, x, vⁱ)
-    return v
+    return hat!(M, v, x, vⁱ)
 end
 
 function hat!(M::Manifold, v, x, vⁱ)
@@ -146,8 +145,7 @@ inverse.
 """
 function vee(M::Manifold, x, v)
     vⁱ = similar_result(M, vee, x, v)
-    vee!(M, vⁱ, x, v)
-    return vⁱ
+    return vee!(M, vⁱ, x, v)
 end
 
 function vee!(M::Manifold, vⁱ, x, v)

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -31,26 +31,45 @@ import Base:
     zero
 import Distributions: _rand!, support
 import LinearAlgebra: cross, det, Diagonal, dot, mul!, norm, I, UniformScaling
-import ManifoldsBase: array_value, base_manifold, check_manifold_point, check_tangent_vector
-import ManifoldsBase: distance, exp, exp!, geodesic, injectivity_radius, inner
-import ManifoldsBase: isapprox, is_manifold_point, is_tangent_vector, is_decorator_manifold
-import ManifoldsBase: inverse_retract, inverse_retract!, log, log!, manifold_dimension, norm
-import ManifoldsBase: project_point, project_point!, project_tangent, project_tangent!
 import ManifoldsBase:
+    array_value,
+    base_manifold,
+    check_manifold_point,
+    check_tangent_vector,
+    distance,
+    exp,
+    exp!,
+    geodesic,
+    injectivity_radius,
+    inner,
+    isapprox,
+    is_manifold_point,
+    is_tangent_vector,
+    is_decorator_manifold,
+    inverse_retract,
+    inverse_retract!,
+    log,
+    log!,
+    manifold_dimension,
+    norm,
+    project_point,
+    project_point!,
+    project_tangent,
+    project_tangent!,
     representation_size,
     retract,
     retract!,
     similar_result,
     similar_result_type,
-    shortest_geodesic
-import ManifoldsBase:
+    shortest_geodesic,
     vector_transport_along,
     vector_transport_along!,
     vector_transport_direction,
     vector_transport_direction!,
     vector_transport_to,
-    vector_transport_to!
-import ManifoldsBase: zero_tangent_vector, zero_tangent_vector!
+    vector_transport_to!,
+    zero_tangent_vector,
+    zero_tangent_vector!
 import Random: rand
 import Statistics: mean, mean!, median, median!, std, var
 import StatsBase: kurtosis, mean_and_std, mean_and_var, moment, skewness

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -83,7 +83,7 @@ using FiniteDifferences
 using HybridArrays
 using LinearAlgebra
 using Base.Iterators: repeated
-using ManifoldsBase: CoTVector, Manifold, MPoint, TVector
+using ManifoldsBase: CoTVector, Manifold, MPoint, TVector, DefaultManifold
 using ManifoldsBase:
     ArrayCoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
 using ManifoldsBase: AbstractRetractionMethod, ExponentialRetraction
@@ -93,7 +93,7 @@ using Markdown: @doc_str
 using Random: AbstractRNG
 using Requires
 using StaticArrays
-using StatsBase: AbstractWeights
+using StatsBase: AbstractWeights, ProbabilityWeights, values, varcorrection
 using UnsafeArrays
 
 """

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -33,6 +33,7 @@ import Base:
     transpose,
     zero
 import Distributions: _rand!, support
+import LightGraphs: AbstractSimpleGraph, is_directed
 import LinearAlgebra: cross, det, Diagonal, dot, mul!, norm, I, UniformScaling
 import ManifoldsBase:
     array_value,
@@ -74,15 +75,17 @@ import ManifoldsBase:
     zero_tangent_vector,
     zero_tangent_vector!
 import Random: rand
+import SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
 import Statistics: mean, mean!, median, median!, std, var
 import StatsBase: kurtosis, mean_and_std, mean_and_var, moment, skewness
 
+using Base.Iterators: repeated
 using Distributions
 using Einsum: @einsum
 using FiniteDifferences
 using HybridArrays
 using LinearAlgebra
-using Base.Iterators: repeated
+using LightGraphs
 using ManifoldsBase: CoTVector, Manifold, MPoint, TVector, DefaultManifold
 using ManifoldsBase:
     ArrayCoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -33,7 +33,6 @@ import Base:
     transpose,
     zero
 import Distributions: _rand!, support
-import LightGraphs: AbstractSimpleGraph, is_directed
 import LinearAlgebra: cross, det, Diagonal, dot, mul!, norm, I, UniformScaling
 import ManifoldsBase:
     array_value,
@@ -75,7 +74,6 @@ import ManifoldsBase:
     zero_tangent_vector,
     zero_tangent_vector!
 import Random: rand
-import SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
 import Statistics: mean, mean!, median, median!, std, var
 import StatsBase: kurtosis, mean_and_std, mean_and_var, moment, skewness
 
@@ -86,6 +84,7 @@ using FiniteDifferences
 using HybridArrays
 using LinearAlgebra
 using LightGraphs
+using LightGraphs: AbstractGraph
 using ManifoldsBase: CoTVector, Manifold, MPoint, TVector, DefaultManifold
 using ManifoldsBase:
     ArrayCoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
@@ -95,6 +94,7 @@ using ManifoldsBase: AbstractVectorTransportMethod, ParallelTransport, Projectio
 using Markdown: @doc_str
 using Random: AbstractRNG
 using Requires
+using SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
 using StaticArrays
 using StatsBase: AbstractWeights, ProbabilityWeights, values, varcorrection
 using UnsafeArrays

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -235,7 +235,9 @@ include("manifolds/Stiefel.jl")
 include("manifolds/Sphere.jl")
 include("manifolds/Symmetric.jl")
 include("manifolds/SymmetricPositiveDefinite.jl")
-
+include("manifolds/SymmetricPositiveDefiniteLinearAffine.jl")
+include("manifolds/SymmetricPositiveDefiniteLogCholesky.jl")
+include("manifolds/SymmetricPositiveDefiniteLogEuclidean.jl")
 
 include("groups/group.jl")
 include("groups/group_action.jl")

--- a/src/SizedAbstractArray.jl
+++ b/src/SizedAbstractArray.jl
@@ -1,5 +1,3 @@
-
-
 # conversion of SizedArray from StaticArrays.jl
 """
     SizedAbstractArray{Tuple{dims...}}(array)
@@ -86,7 +84,6 @@ end
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedAbstractArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-import Base.Array
 @inline function Array(sa::SizedAbstractArray{S}) where {S}
     return Array(reshape(sa.data, size_to_tuple(S)))
 end

--- a/src/SizedAbstractArray.jl
+++ b/src/SizedAbstractArray.jl
@@ -38,7 +38,6 @@ end
 @inline function SizedAbstractArray{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}}
     return SizedAbstractArray{S,T,StaticArrays.tuple_length(S),M,TData}(a)
 end
-
 @inline function SizedAbstractArray{S,T,N}(::UndefInitializer) where {S,T,N}
     return SizedAbstractArray{S,T,N,N}(undef)
 end
@@ -66,7 +65,6 @@ end
         return a
     end
 end
-
 @inline function SizedAbstractArray{S,T,N}(x::Tuple) where {S,T,N}
     return SizedAbstractArray{S,T,N,N,Array{T,N}}(collect(x))
 end
@@ -105,11 +103,13 @@ end
 end
 
 Base.@propagate_inbounds getindex(a::SizedAbstractArray, i::Int) = getindex(a.data, i)
+
 Base.@propagate_inbounds function setindex!(a::SizedAbstractArray, v, i::Int)
     return setindex!(a.data, v, i)
 end
 
-SizedAbstractVector{S,T,M} = SizedAbstractArray{Tuple{S},T,1,M}
+const SizedAbstractVector{S,T,M} = SizedAbstractArray{Tuple{S},T,1,M}
+
 @inline function SizedAbstractVector{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}}
     return SizedAbstractArray{Tuple{S},T,1,M,TData}(a)
 end
@@ -117,7 +117,8 @@ end
     return SizedAbstractArray{Tuple{S},T,1,1,Vector{T}}(x)
 end
 
-SizedAbstractMatrix{S1,S2,T,M} = SizedAbstractArray{Tuple{S1,S2},T,2,M}
+const SizedAbstractMatrix{S1,S2,T,M} = SizedAbstractArray{Tuple{S1,S2},T,2,M}
+
 @inline function SizedAbstractMatrix{S1,S2}(
     a::TData,
 ) where {S1,S2,T,M,TData<:AbstractArray{T,M}}
@@ -145,6 +146,7 @@ end
 function similar(::Type{SA}, ::Type{T}, s::Size{S}) where {SA<:SizedAbstractArray,T,S}
     return sizedabstractarray_similar_type(T, s, StaticArrays.length_val(s))(undef)
 end
+
 function sizedabstractarray_similar_type(
     ::Type{T},
     s::Size{S},

--- a/src/SizedAbstractArray.jl
+++ b/src/SizedAbstractArray.jl
@@ -9,31 +9,40 @@ methods defined by the static array package. The size is checked once upon
 construction to determine if the number of elements (`length`) match, but the
 array may be reshaped.
 """
-struct SizedAbstractArray{S<:Tuple, T, N, M, TData<:AbstractArray{T,M}} <: StaticArray{S, T, N}
+struct SizedAbstractArray{S<:Tuple,T,N,M,TData<:AbstractArray{T,M}} <: StaticArray{S,T,N}
     data::TData
 
-    function SizedAbstractArray{S, T, N, M, TData}(a::TData) where {S, T, N, M, TData<:AbstractArray}
+    function SizedAbstractArray{S,T,N,M,TData}(
+        a::TData,
+    ) where {S,T,N,M,TData<:AbstractArray}
         if length(a) != StaticArrays.tuple_prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
         new{S,T,N,M,TData}(a)
     end
 
-    function SizedAbstractArray{S, T, N, 1}(::UndefInitializer) where {S, T, N}
-        new{S, T, N, 1, Array{T, 1}}(Array{T, 1}(undef, StaticArrays.tuple_prod(S)))
+    function SizedAbstractArray{S,T,N,1}(::UndefInitializer) where {S,T,N}
+        new{S,T,N,1,Array{T,1}}(Array{T,1}(undef, StaticArrays.tuple_prod(S)))
     end
-    function SizedAbstractArray{S, T, N, N}(::UndefInitializer) where {S, T, N}
-        new{S, T, N, N, Array{T, N}}(Array{T, N}(undef, size_to_tuple(S)...))
+    function SizedAbstractArray{S,T,N,N}(::UndefInitializer) where {S,T,N}
+        new{S,T,N,N,Array{T,N}}(Array{T,N}(undef, size_to_tuple(S)...))
     end
 end
 
-@inline SizedAbstractArray{S,T,N}(a::TData) where {S,T,N,M,TData<:AbstractArray{T,M}} = SizedAbstractArray{S,T,N,M,TData}(a)
-@inline SizedAbstractArray{S,T}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} = SizedAbstractArray{S,T,StaticArrays.tuple_length(S),M,TData}(a)
-@inline SizedAbstractArray{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} = SizedAbstractArray{S,T,StaticArrays.tuple_length(S),M,TData}(a)
+@inline SizedAbstractArray{S,T,N}(a::TData) where {S,T,N,M,TData<:AbstractArray{T,M}} =
+    SizedAbstractArray{S,T,N,M,TData}(a)
+@inline SizedAbstractArray{S,T}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} =
+    SizedAbstractArray{S,T,StaticArrays.tuple_length(S),M,TData}(a)
+@inline SizedAbstractArray{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} =
+    SizedAbstractArray{S,T,StaticArrays.tuple_length(S),M,TData}(a)
 
-@inline SizedAbstractArray{S,T,N}(::UndefInitializer) where {S,T,N} = SizedAbstractArray{S,T,N,N}(undef)
-@inline SizedAbstractArray{S,T}(::UndefInitializer) where {S,T} = SizedAbstractArray{S,T,StaticArrays.tuple_length(S),StaticArrays.tuple_length(S)}(undef)
-@generated function (::Type{SizedAbstractArray{S,T,N,M,TData}})(x::NTuple{L,Any}) where {S,T,N,M,TData,L}
+@inline SizedAbstractArray{S,T,N}(::UndefInitializer) where {S,T,N} =
+    SizedAbstractArray{S,T,N,N}(undef)
+@inline SizedAbstractArray{S,T}(::UndefInitializer) where {S,T} =
+    SizedAbstractArray{S,T,StaticArrays.tuple_length(S),StaticArrays.tuple_length(S)}(undef)
+@generated function (::Type{SizedAbstractArray{S,T,N,M,TData}})(
+    x::NTuple{L,Any},
+) where {S,T,N,M,TData,L}
     if L != StaticArrays.tuple_prod(S)
         error("Dimension mismatch")
     end
@@ -46,44 +55,64 @@ end
     end
 end
 
-@inline SizedAbstractArray{S,T,N}(x::Tuple) where {S,T,N} = SizedAbstractArray{S,T,N,N,Array{T,N}}(collect(x))
-@inline SizedAbstractArray{S,T}(x::Tuple) where {S,T} = SizedAbstractArray{S,T,StaticArrays.tuple_length(S)}(x)
+@inline SizedAbstractArray{S,T,N}(x::Tuple) where {S,T,N} =
+    SizedAbstractArray{S,T,N,N,Array{T,N}}(collect(x))
+@inline SizedAbstractArray{S,T}(x::Tuple) where {S,T} =
+    SizedAbstractArray{S,T,StaticArrays.tuple_length(S)}(x)
 @inline SizedAbstractArray{S}(x::NTuple{L,T}) where {S,T,L} = SizedAbstractArray{S,T}(x)
 
 # Overide some problematic default behaviour
-@inline convert(::Type{SA}, sa::SizedAbstractArray) where {SA<:SizedAbstractArray} = SA(sa.data)
+@inline convert(::Type{SA}, sa::SizedAbstractArray) where {SA<:SizedAbstractArray} =
+    SA(sa.data)
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedAbstractArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
 import Base.Array
-@inline Array(sa::SizedAbstractArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline Array{T}(sa::SizedAbstractArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline Array{T,N}(sa::SizedAbstractArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array(sa::SizedAbstractArray{S}) where {S} =
+    Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array{T}(sa::SizedAbstractArray{S,T}) where {T,S} =
+    Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array{T,N}(sa::SizedAbstractArray{S,T,N}) where {T,S,N} =
+    Array(reshape(sa.data, size_to_tuple(S)))
 
-@inline convert(::Type{Array}, sa::SizedAbstractArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T}}, sa::SizedAbstractArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T,N}}, sa::SizedAbstractArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array}, sa::SizedAbstractArray{S}) where {S} =
+    Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T}}, sa::SizedAbstractArray{S,T}) where {T,S} =
+    Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T,N}}, sa::SizedAbstractArray{S,T,N}) where {T,S,N} =
+    Array(reshape(sa.data, size_to_tuple(S)))
 
 Base.@propagate_inbounds getindex(a::SizedAbstractArray, i::Int) = getindex(a.data, i)
-Base.@propagate_inbounds setindex!(a::SizedAbstractArray, v, i::Int) = setindex!(a.data, v, i)
+Base.@propagate_inbounds setindex!(a::SizedAbstractArray, v, i::Int) =
+    setindex!(a.data, v, i)
 
 SizedAbstractVector{S,T,M} = SizedAbstractArray{Tuple{S},T,1,M}
-@inline SizedAbstractVector{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} = SizedAbstractArray{Tuple{S},T,1,M,TData}(a)
-@inline SizedAbstractVector{S}(x::NTuple{L,T}) where {S,T,L} = SizedAbstractArray{Tuple{S},T,1,1,Vector{T}}(x)
+@inline SizedAbstractVector{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}} =
+    SizedAbstractArray{Tuple{S},T,1,M,TData}(a)
+@inline SizedAbstractVector{S}(x::NTuple{L,T}) where {S,T,L} =
+    SizedAbstractArray{Tuple{S},T,1,1,Vector{T}}(x)
 
 SizedAbstractMatrix{S1,S2,T,M} = SizedAbstractArray{Tuple{S1,S2},T,2,M}
-@inline SizedAbstractMatrix{S1,S2}(a::TData) where {S1,S2,T,M,TData<:AbstractArray{T,M}} = SizedAbstractArray{Tuple{S1,S2},T,2,M,TData}(a)
-@inline SizedAbstractMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L} = SizedAbstractArray{Tuple{S1,S2},T,2,2,Matrix{T}}(x)
+@inline SizedAbstractMatrix{S1,S2}(a::TData) where {S1,S2,T,M,TData<:AbstractArray{T,M}} =
+    SizedAbstractArray{Tuple{S1,S2},T,2,M,TData}(a)
+@inline SizedAbstractMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L} =
+    SizedAbstractArray{Tuple{S1,S2},T,2,2,Matrix{T}}(x)
 
 Base.dataids(sa::SizedAbstractArray) = Base.dataids(sa.data)
 
-function promote_rule(::Type{<:SizedAbstractArray{S,T,N,M,TDataA}}, ::Type{<:SizedAbstractArray{S,U,N,M,TDataB}}) where {S,T,U,N,M,TDataA,TDataB}
-    TU = promote_type(T,U)
+function promote_rule(
+    ::Type{<:SizedAbstractArray{S,T,N,M,TDataA}},
+    ::Type{<:SizedAbstractArray{S,U,N,M,TDataB}},
+) where {S,T,U,N,M,TDataA,TDataB}
+    TU = promote_type(T, U)
     SizedAbstractArray{S,TU,N,M,promote_type(TDataA, TDataB)::Type{<:AbstractArray{TU}}}
 end
 
 @inline copy(a::SizedAbstractArray) = typeof(a)(copy(a.data))
 
-similar(::Type{<:SizedAbstractArray{S,T,N,M}},::Type{T2}) where {S,T,N,M,T2} = SizedAbstractArray{S,T2,N,M}(undef)
-similar(::Type{SA},::Type{T},s::Size{S}) where {SA<:SizedAbstractArray,T,S} = sizedabstractarray_similar_type(T,s,StaticArrays.length_val(s))(undef)
-sizedabstractarray_similar_type(::Type{T},s::Size{S},::Type{Val{D}}) where {T,S,D} = SizedAbstractArray{Tuple{S...},T,D,length(s)}
+similar(::Type{<:SizedAbstractArray{S,T,N,M}}, ::Type{T2}) where {S,T,N,M,T2} =
+    SizedAbstractArray{S,T2,N,M}(undef)
+similar(::Type{SA}, ::Type{T}, s::Size{S}) where {SA<:SizedAbstractArray,T,S} =
+    sizedabstractarray_similar_type(T, s, StaticArrays.length_val(s))(undef)
+sizedabstractarray_similar_type(::Type{T}, s::Size{S}, ::Type{Val{D}}) where {T,S,D} =
+    SizedAbstractArray{Tuple{S...},T,D,length(s)}

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -17,7 +17,8 @@ adbackend(backend::Symbol) = adbackend(Val(backend))
 adbackend(backend::Val{:default}) = adbackend()
 
 function adbackend(backend::Val{T}) where {T}
-    T in _adbackends || throw(ArgumentError("Invalid AD backend $(T). Valid options are $(adbackends())."))
+    T in _adbackends ||
+    throw(ArgumentError("Invalid AD backend $(T). Valid options are $(adbackends())."))
     return T
 end
 

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -17,9 +17,8 @@ adbackend(backend::Symbol) = adbackend(Val(backend))
 adbackend(backend::Val{:default}) = adbackend()
 
 function adbackend(backend::Val{T}) where {T}
-    T in _adbackends ||
+    T in _adbackends && return T
     throw(ArgumentError("Invalid AD backend $(T). Valid options are $(adbackends())."))
-    return T
 end
 
 """

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,6 +1,3 @@
-
-using Distributions
-
 """
     FVectorvariate
 

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -31,7 +31,6 @@ For example used for tangent vector-valued distributions.
 abstract type FVectorDistribution{TSpace<:VectorBundleFibers,T} <:
               Distribution{FVectorvariate,FVectorSupport{TSpace,T}} end
 
-
 """
     MPointvariate
 

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -7,8 +7,7 @@ using Distributions
 Structure that subtypes `VariateForm`, indicating that a single sample
 is a vector from a fiber of a vector bundle.
 """
-struct FVectorvariate <: VariateForm
-end
+struct FVectorvariate <: VariateForm end
 
 """
     FVectorSupport(space::Manifold, VectorBundleFibers)
@@ -17,7 +16,7 @@ Value support for vector bundle fiber-valued distributions (values from a fiber 
 bundle at point `x` from the given manifold).
 For example used for tangent vector-valued distributions.
 """
-struct FVectorSupport{TSpace<:VectorBundleFibers, T} <: ValueSupport
+struct FVectorSupport{TSpace<:VectorBundleFibers,T} <: ValueSupport
     space::TSpace
     x::T
 end
@@ -29,8 +28,8 @@ An abstract distribution for vector bundle fiber-valued distributions (values fr
 of a vector bundle at point `x` from the given manifold).
 For example used for tangent vector-valued distributions.
 """
-abstract type FVectorDistribution{TSpace<:VectorBundleFibers, T} <: Distribution{FVectorvariate, FVectorSupport{TSpace, T}}
-end
+abstract type FVectorDistribution{TSpace<:VectorBundleFibers,T} <:
+              Distribution{FVectorvariate,FVectorSupport{TSpace,T}} end
 
 
 """
@@ -39,8 +38,7 @@ end
 Structure that subtypes `VariateForm`, indicating that a single sample
 is a point on a manifold.
 """
-struct MPointvariate <: VariateForm
-end
+struct MPointvariate <: VariateForm end
 
 """
     MPointSupport(M::Manifold)
@@ -57,14 +55,14 @@ end
 
 An abstract distribution for points on manifold of type `TM`.
 """
-abstract type MPointDistribution{TM<:Manifold} <: Distribution{MPointvariate, MPointSupport{TM}}
-end
+abstract type MPointDistribution{TM<:Manifold} <:
+              Distribution{MPointvariate,MPointSupport{TM}} end
 
 """
     support(d::FVectorDistribution)
 
 Get the object of type `FVectorSupport` for the distribution `d`.
 """
-function Distributions.support(::T) where T<:FVectorDistribution
+function Distributions.support(::T) where {T<:FVectorDistribution}
     error("support not implemented for type $T")
 end

--- a/src/groups/array_manifold.jl
+++ b/src/groups/array_manifold.jl
@@ -3,13 +3,6 @@ array_value(e::Identity) = e
 array_point(x) = ArrayMPoint(x)
 array_point(e::Identity) = e
 
-function inv!(M::ArrayManifold, y, x; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    inv!(M.manifold, array_value(y), array_value(x))
-    is_manifold_point(M, y, true; kwargs...)
-    return y
-end
-
 function inv(M::ArrayManifold, x; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
     y = array_point(inv(M.manifold, array_value(x)))
@@ -17,9 +10,9 @@ function inv(M::ArrayManifold, x; kwargs...)
     return y
 end
 
-function identity!(M::ArrayManifold, y, x; kwargs...)
+function inv!(M::ArrayManifold, y, x; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
-    identity!(M.manifold, array_value(y), array_value(x))
+    inv!(M.manifold, array_value(y), array_value(x))
     is_manifold_point(M, y, true; kwargs...)
     return y
 end
@@ -27,6 +20,13 @@ end
 function identity(M::ArrayManifold, x; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
     y = array_point(identity(M.manifold, array_value(x)))
+    is_manifold_point(M, y, true; kwargs...)
+    return y
+end
+
+function identity!(M::ArrayManifold, y, x; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    identity!(M.manifold, array_value(y), array_value(x))
     is_manifold_point(M, y, true; kwargs...)
     return y
 end

--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -86,9 +86,7 @@ distance(G::GroupManifold, x, y) = distance(G.manifold, x, y)
 exp(G::GroupManifold, x, v) = exp(G.manifold, x, v)
 exp!(G::GroupManifold, y, x, v) = exp!(G.manifold, y, x, v)
 injectivity_radius(G::GroupManifold) = injectivity_radius(G.manifold)
-function injectivity_radius(G::GroupManifold, x)
-    return injectivity_radius(G.manifold, x)
-end
+injectivity_radius(G::GroupManifold, x) = injectivity_radius(G.manifold, x)
 function injectivity_radius(G::GroupManifold, x, method::AbstractRetractionMethod)
     return injectivity_radius(G.manifold, x, method)
 end
@@ -584,10 +582,7 @@ const AdditionGroup = AbstractGroupManifold{AdditionOperation}
 
 zero(e::Identity{G}) where {G<:AdditionGroup} = e
 
-function identity!(::AdditionGroup, y, x)
-    fill!(y, 0)
-    return y
-end
+identity!(::AdditionGroup, y, x) = fill!(y, 0)
 
 identity(::AdditionGroup, x) = zero(x)
 

--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -195,6 +195,7 @@ The group identity element $e ∈ G$.
 struct Identity{G<:AbstractGroupManifold}
     group::G
 end
+
 Identity(M::Manifold) = Identity(M, is_decorator_manifold(M))
 Identity(M::Manifold, ::Val{true}) = Identity(M.manifold)
 Identity(M::Manifold, ::Val{false}) = error("Identity not implemented for manifold $(M)")
@@ -233,19 +234,6 @@ end
 ##########################
 
 @doc doc"""
-    inv!(G::AbstractGroupManifold, y, x)
-
-Inverse $x^{-1} ∈ G$ of an element $x ∈ G$, such that
-$x \circ x^{-1} = x^{-1} \circ x = e ∈ G$.
-The result is saved to `y`.
-"""
-inv!(M::Manifold, y, x) = inv!(M, y, x, is_decorator_manifold(M))
-inv!(M::Manifold, y, x, ::Val{true}) = inv!(M.manifold, y, x)
-function inv!(M::Manifold, y, x, ::Val{false})
-    return error("inv! not implemented on $(typeof(M)) for points $(typeof(x))")
-end
-
-@doc doc"""
     inv(G::AbstractGroupManifold, x)
 
 Inverse $x^{-1} ∈ G$ of an element $x ∈ G$, such that
@@ -261,10 +249,17 @@ function inv(G::AbstractGroupManifold, x)
     return inv!(G, y, x)
 end
 
-identity!(M::Manifold, y, x) = identity!(M, y, x, is_decorator_manifold(M))
-identity!(M::Manifold, y, x, ::Val{true}) = identity!(M.manifold, y, x)
-function identity!(M::Manifold, y, x, ::Val{false})
-    return error("identity! not implemented on $(typeof(M)) for points $(typeof(y)) and $(typeof(x))")
+@doc doc"""
+    inv!(G::AbstractGroupManifold, y, x)
+
+Inverse $x^{-1} ∈ G$ of an element $x ∈ G$, such that
+$x \circ x^{-1} = x^{-1} \circ x = e ∈ G$.
+The result is saved to `y`.
+"""
+inv!(M::Manifold, y, x) = inv!(M, y, x, is_decorator_manifold(M))
+inv!(M::Manifold, y, x, ::Val{true}) = inv!(M.manifold, y, x)
+function inv!(M::Manifold, y, x, ::Val{false})
+    return error("inv! not implemented on $(typeof(M)) for points $(typeof(x))")
 end
 
 @doc doc"""
@@ -281,6 +276,12 @@ end
 function identity(G::AbstractGroupManifold, x)
     y = similar_result(G, identity, x)
     return identity!(G, y, x)
+end
+
+identity!(M::Manifold, y, x) = identity!(M, y, x, is_decorator_manifold(M))
+identity!(M::Manifold, y, x, ::Val{true}) = identity!(M.manifold, y, x)
+function identity!(M::Manifold, y, x, ::Val{false})
+    return error("identity! not implemented on $(typeof(M)) for points $(typeof(y)) and $(typeof(x))")
 end
 
 isapprox(M::Manifold, x, e::Identity; kwargs...) = isapprox(M, e, x; kwargs...)
@@ -582,13 +583,13 @@ const AdditionGroup = AbstractGroupManifold{AdditionOperation}
 
 zero(e::Identity{G}) where {G<:AdditionGroup} = e
 
-identity!(::AdditionGroup, y, x) = fill!(y, 0)
-
 identity(::AdditionGroup, x) = zero(x)
 
-inv!(::AdditionGroup, y, x) = copyto!(y, -x)
+identity!(::AdditionGroup, y, x) = fill!(y, 0)
 
 inv(::AdditionGroup, x) = -x
+
+inv!(::AdditionGroup, y, x) = copyto!(y, -x)
 
 compose(::AdditionGroup, x, y) = x + y
 
@@ -649,17 +650,17 @@ function LinearAlgebra.mul!(y, e::E, ::E) where {G<:MultiplicationGroup,E<:Ident
     return identity!(e.group, y, e)
 end
 
+identity(::MultiplicationGroup, x) = one(x)
+
 function identity!(G::GT, y, x) where {GT<:MultiplicationGroup}
     isa(x, Identity{GT}) || return copyto!(y, one(x))
     error("identity! not implemented on $(typeof(G)) for points $(typeof(y)) and $(typeof(x))")
 end
 identity!(::MultiplicationGroup, y::AbstractMatrix, x) = copyto!(y, I)
 
-identity(::MultiplicationGroup, x) = one(x)
+inv(::MultiplicationGroup, x) = inv(x)
 
 inv!(G::MultiplicationGroup, y, x) = copyto!(y, inv(G, x))
-
-inv(::MultiplicationGroup, x) = inv(x)
 
 compose(::MultiplicationGroup, x, y) = x * y
 

--- a/src/groups/group_action.jl
+++ b/src/groups/group_action.jl
@@ -28,20 +28,6 @@ Get the direction of the action
 """
 direction(::AbstractGroupAction{AD}) where {AD} = AD()
 
-"""
-    apply!(A::AbstractGroupAction, y, a, x)
-
-Apply action `a` to the point `x` with the rule specified by `A`.
-The result is saved in `y`.
-"""
-function apply!(A::AbstractGroupAction{LeftAction}, y, a, x)
-    error("apply! not implemented for action $(typeof(A)) and points $(typeof(y)), $(typeof(x)) and $(typeof(a)).")
-end
-function apply!(A::AbstractGroupAction{RightAction}, y, a, x)
-    ainv = inv(base_group(A), a)
-    return apply!(switch_direction(A), y, ainv, x)
-end
-
 @doc doc"""
     apply(A::AbstractGroupAction, a, x)
 
@@ -59,14 +45,17 @@ function apply(A::AbstractGroupAction, a, x)
 end
 
 """
-    inverse_apply!(A::AbstractGroupAction, y, a, x)
+    apply!(A::AbstractGroupAction, y, a, x)
 
-Apply inverse of action `a` to the point `x` with the rule specified by `A`.
+Apply action `a` to the point `x` with the rule specified by `A`.
 The result is saved in `y`.
 """
-function inverse_apply!(A::AbstractGroupAction, y, a, x)
-    inva = inv(base_group(A), a)
-    return apply!(A, y, inva, x)
+function apply!(A::AbstractGroupAction{LeftAction}, y, a, x)
+    error("apply! not implemented for action $(typeof(A)) and points $(typeof(y)), $(typeof(x)) and $(typeof(a)).")
+end
+function apply!(A::AbstractGroupAction{RightAction}, y, a, x)
+    ainv = inv(base_group(A), a)
+    return apply!(switch_direction(A), y, ainv, x)
 end
 
 """
@@ -77,6 +66,17 @@ Apply inverse of action `a` to the point `x`. The action is specified by `A`.
 function inverse_apply(A::AbstractGroupAction, a, x)
     y = similar_result(A, inverse_apply, x, a)
     return inverse_apply!(A, y, a, x)
+end
+
+"""
+    inverse_apply!(A::AbstractGroupAction, y, a, x)
+
+Apply inverse of action `a` to the point `x` with the rule specified by `A`.
+The result is saved in `y`.
+"""
+function inverse_apply!(A::AbstractGroupAction, y, a, x)
+    inva = inv(base_group(A), a)
+    return apply!(A, y, inva, x)
 end
 
 @doc doc"""
@@ -97,7 +97,6 @@ transports vectors
 function apply_diff(A::AbstractGroupAction, a, x, v)
     return error("apply_diff not implemented for action $(typeof(A)), points $(typeof(a)) and $(typeof(x)), and vector $(typeof(v))")
 end
-
 
 function apply_diff!(A::AbstractGroupAction, vout, a, x, v)
     return error("apply_diff! not implemented for action $(typeof(A)), points $(typeof(a)) and $(typeof(x)), vectors $(typeof(vout)) and $(typeof(v))")

--- a/src/groups/group_operation_action.jl
+++ b/src/groups/group_operation_action.jl
@@ -26,32 +26,32 @@ function switch_direction(A::GroupOperationAction)
     return GroupOperationAction(A.group, switch_direction(direction(A)))
 end
 
-apply!(A::GroupOperationAction, y, a, x) = translate!(A.group, y, a, x, direction(A))
-
 apply(A::GroupOperationAction, a, x) = translate(A.group, a, x, direction(A))
 
-function inverse_apply!(A::GroupOperationAction, y, a, x)
-    return inverse_translate!(A.group, y, a, x, direction(A))
-end
+apply!(A::GroupOperationAction, y, a, x) = translate!(A.group, y, a, x, direction(A))
 
 function inverse_apply(A::GroupOperationAction, a, x)
     return inverse_translate(A.group, a, x, direction(A))
 end
 
-function apply_diff!(A::GroupOperationAction, vout, a, x, v)
-    return translate_diff!(A.group, vout, a, x, v, direction(A))
+function inverse_apply!(A::GroupOperationAction, y, a, x)
+    return inverse_translate!(A.group, y, a, x, direction(A))
 end
 
 function apply_diff(A::GroupOperationAction, a, x, v)
     return translate_diff(A.group, a, x, v, direction(A))
 end
 
-function inverse_apply_diff!(A::GroupOperationAction, vout, a, x, v)
-    return inverse_translate_diff!(A.group, vout, a, x, v, direction(A))
+function apply_diff!(A::GroupOperationAction, vout, a, x, v)
+    return translate_diff!(A.group, vout, a, x, v, direction(A))
 end
 
 function inverse_apply_diff(A::GroupOperationAction, a, x, v)
     return inverse_translate_diff(A.group, a, x, v, direction(A))
+end
+
+function inverse_apply_diff!(A::GroupOperationAction, vout, a, x, v)
+    return inverse_translate_diff!(A.group, vout, a, x, v, direction(A))
 end
 
 function optimal_alignment(A::GroupOperationAction, x1, x2)
@@ -71,7 +71,6 @@ function center_of_orbit(
     m = mean(A.group, pts, mean_method)
     return inverse_apply(switch_direction(A), q, m)
 end
-
 function center_of_orbit(A::GroupOperationAction, pts::AbstractVector, q)
     m = mean(A.group, pts)
     return inverse_apply(switch_direction(A), q, m)

--- a/src/groups/product_group.jl
+++ b/src/groups/product_group.jl
@@ -51,8 +51,7 @@ function inv(M::ProductManifold, x::ProductRepr)
 end
 function inv(M::ProductManifold, x)
     y = similar_result(M, inv, x)
-    inv!(M, y, x)
-    return y
+    return inv!(M, y, x)
 end
 
 inv!(G::ProductGroup, y, x) = inv!(G.manifold, y, x)
@@ -68,8 +67,7 @@ function identity(M::ProductManifold, x::ProductRepr)
 end
 function identity(M::ProductManifold, x)
     y = similar_result(M, identity, x)
-    identity!(M, y, x)
-    return y
+    return identity!(M, y, x)
 end
 
 identity!(G::ProductGroup, y, x) = identity!(G.manifold, y, x)
@@ -92,8 +90,7 @@ function compose(M::ProductManifold, x::ProductRepr, y::ProductRepr)
 end
 function compose(M::ProductManifold, x, y)
     z = similar_result(M, compose, x, y)
-    compose!(M, z, x, y)
-    return z
+    return compose!(M, z, x, y)
 end
 
 compose!(G::ProductGroup, z, x, y) = compose!(G.manifold, z, x, y)
@@ -125,8 +122,7 @@ function translate(
 end
 function translate(M::ProductManifold, x, y, conv::ActionDirection)
     z = similar_result(M, translate, x, y)
-    translate!(M, z, x, y, conv)
-    return z
+    return translate!(M, z, x, y, conv)
 end
 
 function translate!(G::ProductGroup, z, x, y, conv::ActionDirection)
@@ -163,8 +159,7 @@ function inverse_translate(
 end
 function inverse_translate(M::ProductManifold, x, y, conv::ActionDirection)
     z = similar_result(M, inverse_translate, x, y)
-    inverse_translate!(M, z, x, y, conv)
-    return z
+    return inverse_translate!(M, z, x, y, conv)
 end
 
 function inverse_translate!(G::ProductGroup, z, x, y, conv::ActionDirection)
@@ -203,8 +198,7 @@ function translate_diff(
 end
 function translate_diff(M::ProductManifold, x, y, v, conv::ActionDirection)
     vout = similar_result(M, translate_diff, v, x, y)
-    translate_diff!(M, vout, x, y, v, conv)
-    return vout
+    return translate_diff!(M, vout, x, y, v, conv)
 end
 
 function translate_diff!(G::ProductGroup, vout, x, y, v, conv::ActionDirection)
@@ -244,8 +238,7 @@ function inverse_translate_diff(
 end
 function inverse_translate_diff(M::ProductManifold, x, y, v, conv::ActionDirection)
     vout = similar_result(M, inverse_translate_diff, v, x, y)
-    inverse_translate_diff!(M, vout, x, y, v, conv)
-    return vout
+    return inverse_translate_diff!(M, vout, x, y, v, conv)
 end
 
 function inverse_translate_diff!(G::ProductGroup, vout, x, y, v, conv::ActionDirection)

--- a/src/groups/product_group.jl
+++ b/src/groups/product_group.jl
@@ -29,19 +29,19 @@ end
 
 show(io::IO, G::ProductGroup) = print(io, "ProductGroup$((G.manifold.manifolds...,))")
 
-function submanifold_components(
-    e::Identity{GT},
-) where {MT<:ProductManifold,GT<:GroupManifold{MT}}
-    M = base_manifold(e.group)
-    return Identity.(M.manifolds)
-end
-
 function submanifold_component(
     e::Identity{GT},
     ::Val{I},
 ) where {I,MT<:ProductManifold,GT<:GroupManifold{MT}}
     M = base_manifold(e.group)
     return Identity(submanifold(M, I))
+end
+
+function submanifold_components(
+    e::Identity{GT},
+) where {MT<:ProductManifold,GT<:GroupManifold{MT}}
+    M = base_manifold(e.group)
+    return Identity.(M.manifolds)
 end
 
 inv(G::ProductGroup, x) = inv(G.manifold, x)

--- a/src/groups/rotation_action.jl
+++ b/src/groups/rotation_action.jl
@@ -40,28 +40,28 @@ function switch_direction(A::RotationAction{TM,TSO,TAD}) where {TM,TSO,TAD}
     return RotationAction(A.M, A.SOn, switch_direction(TAD()))
 end
 
-apply!(A::RotationActionOnVector{N,F,LeftAction}, y, a, x) where {N,F} = mul!(y, a, x)
-
 apply(A::RotationActionOnVector{N,F,LeftAction}, a, x) where {N,F} = a * x
 function apply(A::RotationActionOnVector{N,F,RightAction}, a, x) where {N,F}
     return inv(base_group(A), a) * x
 end
+
+apply!(A::RotationActionOnVector{N,F,LeftAction}, y, a, x) where {N,F} = mul!(y, a, x)
 
 function inverse_apply(A::RotationActionOnVector{N,F,LeftAction}, a, x) where {N,F}
     return inv(base_group(A), a) * x
 end
 inverse_apply(A::RotationActionOnVector{N,F,RightAction}, a, x) where {N,F} = a * x
 
+apply_diff(A::RotationActionOnVector{N,F,LeftAction}, a, x, v) where {N,F} = a * v
+function apply_diff(A::RotationActionOnVector{N,F,RightAction}, a, x, v) where {N,F}
+    return inv(base_group(A), a) * v
+end
+
 function apply_diff!(A::RotationActionOnVector{N,F,LeftAction}, vout, a, x, v) where {N,F}
     return mul!(vout, a, v)
 end
 function apply_diff!(A::RotationActionOnVector{N,F,RightAction}, vout, a, x, v) where {N,F}
     return mul!(vout, inv(base_group(A), a), v)
-end
-
-apply_diff(A::RotationActionOnVector{N,F,LeftAction}, a, x, v) where {N,F} = a * v
-function apply_diff(A::RotationActionOnVector{N,F,RightAction}, a, x, v) where {N,F}
-    return inv(base_group(A), a) * v
 end
 
 function inverse_apply_diff(A::RotationActionOnVector{N,F,LeftAction}, a, x, v) where {N,F}
@@ -80,7 +80,6 @@ function optimal_alignment(A::RotationActionOnVector{N,T,LeftAction}, x1, x2) wh
     Ostar = det(UVt) ≥ 0 ? UVt : F.U * Diagonal([i < L ? 1 : -1 for i = 1:L]) * F.Vt
     return convert(typeof(Xmul), Ostar)
 end
-
 function optimal_alignment(A::RotationActionOnVector{N,T,RightAction}, x1, x2) where {N,T}
     return optimal_alignment(switch_direction(A), x2, x1)
 end

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -49,6 +49,7 @@ function show(io::IO, G::SemidirectProductGroup)
 end
 
 _padpoint!(G::SemidirectProductGroup, y) = y
+
 _padvector!(G::SemidirectProductGroup, v) = v
 
 inv(G::GT, e::Identity{GT}) where {GT<:SemidirectProductGroup} = e

--- a/src/groups/special_orthogonal.jl
+++ b/src/groups/special_orthogonal.jl
@@ -10,9 +10,9 @@ const SpecialOrthogonal{n} = GroupManifold{Rotations{n},MultiplicationOperation}
 
 SpecialOrthogonal(n) = SpecialOrthogonal{n}(Rotations(n), MultiplicationOperation())
 
-inv(::SpecialOrthogonal, x) = transpose(x)
-
 show(io::IO, ::SpecialOrthogonal{n}) where {n} = print(io, "SpecialOrthogonal($(n))")
+
+inv(::SpecialOrthogonal, x) = transpose(x)
 
 inverse_translate(G::SpecialOrthogonal, x, y, conv::LeftAction) = inv(G, x) * y
 inverse_translate(G::SpecialOrthogonal, x, y, conv::RightAction) = y * inv(G, x)

--- a/src/groups/translation_action.jl
+++ b/src/groups/translation_action.jl
@@ -36,20 +36,20 @@ function switch_direction(A::TranslationAction{TM,TRN,TAD}) where {TM,TRN,TAD}
     return TranslationAction(A.M, A.Rn, switch_direction(TAD()))
 end
 
+apply(A::TranslationAction, a, x) = x + a
+
 apply!(A::TranslationAction{M,G}, y, a, x) where {M,G} = (y .= x .+ a)
 apply!(A::TranslationAction{M,G}, y, e::Identity{G}, x) where {M,G} = copyto!(y, x)
 
-apply(A::TranslationAction, a, x) = x + a
+inverse_apply(A::TranslationAction, a, x) = x - a
 
 inverse_apply!(A::TranslationAction{M,G}, y, a, x) where {M,G} = (y .= x .- a)
 inverse_apply!(A::TranslationAction{M,G}, y, e::Identity{G}, x) where {M,G} = copyto!(y, x)
 
-inverse_apply(A::TranslationAction, a, x) = x - a
+apply_diff(A::TranslationAction, a, x, v) = v
 
 apply_diff!(A::TranslationAction, vout, a, x, v) = copyto!(vout, v)
 
-apply_diff(A::TranslationAction, a, x, v) = v
+inverse_apply_diff(A::TranslationAction, a, x, v) = v
 
 inverse_apply_diff!(A::TranslationAction, vout, a, x, v) = copyto!(vout, v)
-
-inverse_apply_diff(A::TranslationAction, a, x, v) = v

--- a/src/groups/translation_action.jl
+++ b/src/groups/translation_action.jl
@@ -36,18 +36,12 @@ function switch_direction(A::TranslationAction{TM,TRN,TAD}) where {TM,TRN,TAD}
     return TranslationAction(A.M, A.Rn, switch_direction(TAD()))
 end
 
-function apply!(A::TranslationAction{M,G}, y, a, x) where {M,G}
-    y .= x .+ a
-    return y
-end
+apply!(A::TranslationAction{M,G}, y, a, x) where {M,G} = (y .= x .+ a)
 apply!(A::TranslationAction{M,G}, y, e::Identity{G}, x) where {M,G} = copyto!(y, x)
 
 apply(A::TranslationAction, a, x) = x + a
 
-function inverse_apply!(A::TranslationAction{M,G}, y, a, x) where {M,G}
-    y .= x .- a
-    return y
-end
+inverse_apply!(A::TranslationAction{M,G}, y, a, x) where {M,G} = (y .= x .- a)
 inverse_apply!(A::TranslationAction{M,G}, y, e::Identity{G}, x) where {M,G} = copyto!(y, x)
 
 inverse_apply(A::TranslationAction, a, x) = x - a

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -1,7 +1,3 @@
-using LinearAlgebra:
-    diag, eigen, eigvals, eigvecs, Symmetric, tr, cholesky, LowerTriangular, UpperTriangular
-
-
 @doc doc"""
     CholeskySpace{N} <: Manifold
 

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -117,10 +117,11 @@ $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 exp(::CholeskySpace, ::Any...)
 function exp!(::CholeskySpace, y, x, v)
-    y .=
+    y .= (
         strictlyLowerTriangular(x) +
         strictlyLowerTriangular(v) +
         Diagonal(diag(x)) * Diagonal(exp.(diag(v) ./ diag(x)))
+    )
     return y
 end
 
@@ -136,9 +137,12 @@ The formula reads
     g_{x}(v,w) = \sum_{i>j} v_{ij}w_{ij} + \sum_{j=1}^m v_{ii}w_{ii}x_{ii}^{-2}
 ````
 """
-inner(::CholeskySpace, x, v, w) =
-    sum(strictlyLowerTriangular(v) .* strictlyLowerTriangular(w)) +
-    sum(diag(v) .* diag(w) ./ (diag(x) .^ 2))
+function inner(::CholeskySpace, x, v, w)
+    return (
+        sum(strictlyLowerTriangular(v) .* strictlyLowerTriangular(w)) +
+        sum(diag(v) .* diag(w) ./ (diag(x) .^ 2))
+    )
+end
 
 @doc doc"""
     log(M::CholeskySpace, v, x, y)
@@ -157,9 +161,10 @@ $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 log(::Cholesky, ::Any...)
 function log!(::CholeskySpace, v, x, y)
-    v .=
+    v .= (
         strictlyLowerTriangular(y) - strictlyLowerTriangular(x) +
         Diagonal(diag(x)) * Diagonal(log.(diag(y) ./ diag(x)))
+    )
     return v
 end
 
@@ -197,9 +202,10 @@ and $\operatorname{diag}$ extracts the diagonal matrix.
 """
 vector_transport_to(::CholeskySpace, ::Any, ::Any, ::Any, ::ParallelTransport)
 function vector_transport_to!(::CholeskySpace, vto, x, v, y, ::ParallelTransport)
-    vto .=
+    vto .= (
         strictlyLowerTriangular(x) +
         Diagonal(diag(y)) * Diagonal(1 ./ diag(x)) * Diagonal(v)
+    )
     return vto
 end
 

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -158,11 +158,11 @@ $\operatorname{diag}(x)$ the diagonal matrix of $x$
 log(::Cholesky, ::Any...)
 
 function log!(::CholeskySpace, v, x, y)
-    v .= (
+    return copyto!(
+        v,
         strictlyLowerTriangular(y) - strictlyLowerTriangular(x) +
-        Diagonal(diag(x)) * Diagonal(log.(diag(y) ./ diag(x)))
+        Diagonal(diag(x) .* log.(diag(y) ./ diag(x))),
     )
-    return v
 end
 
 @doc doc"""
@@ -201,11 +201,10 @@ and $\operatorname{diag}$ extracts the diagonal matrix.
 vector_transport_to(::CholeskySpace, ::Any, ::Any, ::Any, ::ParallelTransport)
 
 function vector_transport_to!(::CholeskySpace, vto, x, v, y, ::ParallelTransport)
-    vto .= (
-        strictlyLowerTriangular(x) +
-        Diagonal(diag(y)) * Diagonal(1 ./ diag(x)) * Diagonal(v)
+    return copyto!(
+        vto,
+        strictlyLowerTriangular(x) + Diagonal(diag(y) .* diag(v) ./ diag(x)),
     )
-    return vto
 end
 
 @doc doc"""

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -1,4 +1,5 @@
-using LinearAlgebra: diag, eigen, eigvals, eigvecs, Symmetric, tr, cholesky, LowerTriangular, UpperTriangular
+using LinearAlgebra:
+    diag, eigen, eigvals, eigvecs, Symmetric, tr, cholesky, LowerTriangular, UpperTriangular
 
 
 @doc doc"""
@@ -31,13 +32,22 @@ The tolerance for the tests can be set using the `kwargs...`.
 """
 function check_manifold_point(M::CholeskySpace, x; kwargs...)
     if size(x) != representation_size(M)
-        return DomainError(size(x),"The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).")
+        return DomainError(
+            size(x),
+            "The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).",
+        )
     end
-    if !isapprox( norm(strictlyUpperTriangular(x)), 0.; kwargs...)
-        return DomainError(norm(UpperTriangular(x) - Diagonal(x)), "The point $(x) does not lie on $(M), since it strictly upper triangular nonzero entries")
+    if !isapprox(norm(strictlyUpperTriangular(x)), 0.0; kwargs...)
+        return DomainError(
+            norm(UpperTriangular(x) - Diagonal(x)),
+            "The point $(x) does not lie on $(M), since it strictly upper triangular nonzero entries",
+        )
     end
-    if any( diag(x) .<= 0)
-        return DomainError(min(diag(x)...), "The point $(x) does not lie on $(M), since it hast nonpositive entries on the diagonal")
+    if any(diag(x) .<= 0)
+        return DomainError(
+            min(diag(x)...),
+            "The point $(x) does not lie on $(M), since it hast nonpositive entries on the diagonal",
+        )
     end
     return nothing
 end
@@ -50,17 +60,22 @@ atfer [`check_manifold_point`](@ref)`(M,x)`, `v` has to be of same dimension as 
 and a symmetric matrix.
 The tolerance for the tests can be set using the `kwargs...`.
 """
-function check_tangent_vector(M::CholeskySpace, x,v; kwargs...)
+function check_tangent_vector(M::CholeskySpace, x, v; kwargs...)
     mpe = check_manifold_point(M, x)
     if mpe !== nothing
         return mpe
     end
     if size(v) != representation_size(M)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $(M) since its size does not match $(representation_size(M)).")
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $(M) since its size does not match $(representation_size(M)).",
+        )
     end
-    if !isapprox( norm(strictlyUpperTriangular(v)), 0.; kwargs...)
-        return DomainError(norm(UpperTriangular(v) - Diagonal(v)), "The matrix $(v) is not a tangent vector at $(x) (represented as an element of the Lie algebra) since it is not lower triangular.")
+    if !isapprox(norm(strictlyUpperTriangular(v)), 0.0; kwargs...)
+        return DomainError(
+            norm(UpperTriangular(v) - Diagonal(v)),
+            "The matrix $(v) is not a tangent vector at $(x) (represented as an element of the Lie algebra) since it is not lower triangular.",
+        )
     end
     return nothing
 end
@@ -78,10 +93,10 @@ d_{\mathcal M}(x,y) = \sqrt{\sum_{i>j} (x_{ij}-y_{ij})^2 +
 }
 ````
 """
-function distance(::CholeskySpace,x,y)
+function distance(::CholeskySpace, x, y)
     return sqrt(
-        sum( (strictlyLowerTriangular(x) - strictlyLowerTriangular(y)).^2 )
-        + sum( (log.(diag(x)) - log.(diag(y))).^2 )
+        sum((strictlyLowerTriangular(x) - strictlyLowerTriangular(y)) .^ 2) +
+        sum((log.(diag(x)) - log.(diag(y))) .^ 2),
     )
 end
 
@@ -101,8 +116,11 @@ where $\lfloor x\rfloor$ denotes the strictly lower triangular matrix of $x$ and
 $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 exp(::CholeskySpace, ::Any...)
-function exp!(::CholeskySpace,y,x,v)
-    y .= strictlyLowerTriangular(x) + strictlyLowerTriangular(v) + Diagonal(diag(x))*Diagonal(exp.(diag(v)./diag(x)))
+function exp!(::CholeskySpace, y, x, v)
+    y .=
+        strictlyLowerTriangular(x) +
+        strictlyLowerTriangular(v) +
+        Diagonal(diag(x)) * Diagonal(exp.(diag(v) ./ diag(x)))
     return y
 end
 
@@ -118,7 +136,9 @@ The formula reads
     g_{x}(v,w) = \sum_{i>j} v_{ij}w_{ij} + \sum_{j=1}^m v_{ii}w_{ii}x_{ii}^{-2}
 ````
 """
-inner(::CholeskySpace,x,v,w) = sum(strictlyLowerTriangular(v).*strictlyLowerTriangular(w)) + sum(diag(v).*diag(w)./( diag(x).^2 ))
+inner(::CholeskySpace, x, v, w) =
+    sum(strictlyLowerTriangular(v) .* strictlyLowerTriangular(w)) +
+    sum(diag(v) .* diag(w) ./ (diag(x) .^ 2))
 
 @doc doc"""
     log(M::CholeskySpace, v, x, y)
@@ -136,8 +156,10 @@ where $\lfloor x\rfloor$ denotes the strictly lower triangular matrix of $x$ and
 $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 log(::Cholesky, ::Any...)
-function log!(::CholeskySpace,v,x,y)
-    v .= strictlyLowerTriangular(y) - strictlyLowerTriangular(x) + Diagonal(diag(x))*Diagonal(log.(diag(y)./diag(x)))
+function log!(::CholeskySpace, v, x, y)
+    v .=
+        strictlyLowerTriangular(y) - strictlyLowerTriangular(x) +
+        Diagonal(diag(x)) * Diagonal(log.(diag(y) ./ diag(x)))
     return v
 end
 
@@ -146,14 +168,14 @@ end
 
 Return the manifold dimension for the [`CholeskySpace`](@ref) `M`, i.e. $\frac{N(N+1)}{2}$.
 """
-@generated manifold_dimension(::CholeskySpace{N}) where N = div(N*(N+1), 2)
+@generated manifold_dimension(::CholeskySpace{N}) where {N} = div(N * (N + 1), 2)
 
 @doc doc"""
     reporesentation_size(M::CholeskySpace)
 
 Return the representation size for the [`CholeskySpace`](@ref)`{N}` `M`, i.e. `(N,N)`.
 """
-@generated representation_size(::CholeskySpace{N}) where N = (N,N)
+@generated representation_size(::CholeskySpace{N}) where {N} = (N, N)
 
 # two small helper for strictly lower and upper triangulars
 strictlyLowerTriangular(x) = LowerTriangular(x) - Diagonal(diag(x))
@@ -175,7 +197,9 @@ and $\operatorname{diag}$ extracts the diagonal matrix.
 """
 vector_transport_to(::CholeskySpace, ::Any, ::Any, ::Any, ::ParallelTransport)
 function vector_transport_to!(::CholeskySpace, vto, x, v, y, ::ParallelTransport)
-    vto .= strictlyLowerTriangular(x) + Diagonal(diag(y))*Diagonal(1 ./ diag(x))*Diagonal(v)
+    vto .=
+        strictlyLowerTriangular(x) +
+        Diagonal(diag(y)) * Diagonal(1 ./ diag(x)) * Diagonal(v)
     return vto
 end
 
@@ -185,7 +209,7 @@ end
 Return the zero tangent vector on the [`CholeskySpace`](@ref) `M` at `x`.
 """
 zero_tangent_vector(::CholeskySpace, ::Any...)
-function zero_tangent_vector!(M::CholeskySpace,v,x)
-    fill!(v,0)
+function zero_tangent_vector!(M::CholeskySpace, v, x)
+    fill!(v, 0)
     return v
 end

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -16,6 +16,7 @@ Generate the manifold of $n\times n$ lower triangular matrices with positive dia
     > Cholesky Decomposition", arXiv: [1908.09326](https://arxiv.org/abs/1908.09326).
 """
 struct CholeskySpace{N} <: Manifold end
+
 CholeskySpace(n::Int) = CholeskySpace{n}()
 
 @doc doc"""
@@ -110,6 +111,7 @@ where $\lfloor x\rfloor$ denotes the strictly lower triangular matrix of $x$ and
 $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 exp(::CholeskySpace, ::Any...)
+
 function exp!(::CholeskySpace, y, x, v)
     y .= (
         strictlyLowerTriangular(x) +
@@ -154,6 +156,7 @@ where $\lfloor x\rfloor$ denotes the strictly lower triangular matrix of $x$ and
 $\operatorname{diag}(x)$ the diagonal matrix of $x$
 """
 log(::Cholesky, ::Any...)
+
 function log!(::CholeskySpace, v, x, y)
     v .= (
         strictlyLowerTriangular(y) - strictlyLowerTriangular(x) +
@@ -176,8 +179,9 @@ Return the representation size for the [`CholeskySpace`](@ref)`{N}` `M`, i.e. `(
 """
 @generated representation_size(::CholeskySpace{N}) where {N} = (N, N)
 
-# two small helper for strictly lower and upper triangulars
+# two small helpers for strictly lower and upper triangulars
 strictlyLowerTriangular(x) = LowerTriangular(x) - Diagonal(diag(x))
+
 strictlyUpperTriangular(x) = UpperTriangular(x) - Diagonal(diag(x))
 
 @doc doc"""
@@ -195,6 +199,7 @@ where $\lfloor\cdot\rfloor$ denotes the strictly lower triangular matrix,
 and $\operatorname{diag}$ extracts the diagonal matrix.
 """
 vector_transport_to(::CholeskySpace, ::Any, ::Any, ::Any, ::ParallelTransport)
+
 function vector_transport_to!(::CholeskySpace, vto, x, v, y, ::ParallelTransport)
     vto .= (
         strictlyLowerTriangular(x) +
@@ -209,4 +214,5 @@ end
 Return the zero tangent vector on the [`CholeskySpace`](@ref) `M` at `x`.
 """
 zero_tangent_vector(::CholeskySpace, ::Any...)
+
 zero_tangent_vector!(M::CholeskySpace, v, x) = fill!(v, 0)

--- a/src/manifolds/CholeskySpace.jl
+++ b/src/manifolds/CholeskySpace.jl
@@ -58,9 +58,7 @@ The tolerance for the tests can be set using the `kwargs...`.
 """
 function check_tangent_vector(M::CholeskySpace, x, v; kwargs...)
     mpe = check_manifold_point(M, x)
-    if mpe !== nothing
-        return mpe
-    end
+    mpe !== nothing && return mpe
     if size(v) != representation_size(M)
         return DomainError(
             size(v),
@@ -211,7 +209,4 @@ end
 Return the zero tangent vector on the [`CholeskySpace`](@ref) `M` at `x`.
 """
 zero_tangent_vector(::CholeskySpace, ::Any...)
-function zero_tangent_vector!(M::CholeskySpace, v, x)
-    fill!(v, 0)
-    return v
-end
+zero_tangent_vector!(M::CholeskySpace, v, x) = fill!(v, 0)

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -13,6 +13,7 @@ alternatively can be set to use the [`AbstractNumbers`](@ref) `f=ℂ` to obtain 
 represented by `ℂ`-valued `Circle` of unit numbers.
 """
 struct Circle{F} <: Manifold where {F<:AbstractNumbers} end
+
 Circle(f::AbstractNumbers = ℝ) = Circle{f}()
 
 @doc doc"""
@@ -23,6 +24,7 @@ For the real-valued case, `x` is an angle and hence it checks that $x \in [-\pi,
 for the complex-valued case its a unit number, $x \in \mathbb C$ with $\lvert x \rvert = 1$.
 """
 check_manifold_point(::Circle, ::Any...)
+
 function check_manifold_point(M::Circle{ℝ}, x; kwargs...)
     if !isapprox(sym_rem(x), x; kwargs...)
         return DomainError(
@@ -41,6 +43,7 @@ function check_manifold_point(M::Circle{ℂ}, x; kwargs...)
     end
     return nothing
 end
+
 """
     check_tangent_vector(M::Circle, x, v)
 
@@ -52,6 +55,7 @@ For the complex-valued case `v` has to lie on the line parallel to the tangent l
 in the complex plane, i.e. the inner product is zero.
 """
 check_tangent_vector(::Circle{ℝ}, ::Any...; ::Any...)
+
 function check_tangent_vector(M::Circle{ℝ}, x, v; kwargs...)
     perr = check_manifold_point(M, x)
     return perr # if x is valid all v that are real numbers are valid
@@ -104,20 +108,21 @@ applied to valuedin the complex plane.
 """
 exp(::Circle, ::Any...)
 exp(::Circle{ℝ}, x::Real, v::Real) = sym_rem(x + v)
-exp!(::Circle{ℝ}, y, x, v) = (y .= sym_rem(x + v))
 function exp(M::Circle{ℂ}, x::Number, v::Number)
     θ = norm(M, x, v)
     return cos(θ) * x + usinc(θ) * v
 end
+
+exp!(::Circle{ℝ}, y, x, v) = (y .= sym_rem(x + v))
 function exp!(M::Circle{ℂ}, y, x, v)
     θ = norm(M, x, v)
     y .= cos(θ) * x + usinc(θ) * v
     return y
 end
 
-flat!(::Circle, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
-
 flat(M::Circle, x::Number, w::TFVector) = FVector(CotangentSpace, w.data)
+
+flat!(::Circle, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_basis(M::Circle{ℝ}, x, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
@@ -126,16 +131,14 @@ function get_basis(M::Circle{ℝ}, x, B::DiagonalizingOrthonormalBasis)
 end
 
 get_coordinates(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis) = v
-
 function get_coordinates(M::Circle{ℝ}, x, v, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
     return v .* (sbv == 0 ? 1 : sbv)
 end
-
 """
     get_coordinates(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
 
-Return tangent vector coordinate in the Lie algebra of the circle.
+Return tangent vector coordinates in the Lie algebra of the circle.
 """
 function get_coordinates(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
     v, x = v[1], x[1]
@@ -144,16 +147,14 @@ function get_coordinates(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
 end
 
 get_vector(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis) = v
-
 function get_vector(M::Circle{ℝ}, x, v, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
     return v .* (sbv == 0 ? 1 : sbv)
 end
-
 """
-    get_coordinates(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
+    get_vector(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
 
-Return tangent vector from the coordinate in the Lie algebra of the circle.
+Return tangent vector from the coordinates in the Lie algebra of the circle.
 """
 get_vector(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis) = @SVector [1im * v[1] * x[1]]
 
@@ -210,7 +211,6 @@ applied to valuedin the complex plane.
 """
 log(::Circle, ::Any...)
 log(::Circle{ℝ}, x::Real, y::Real) = sym_rem(y - x)
-log!(::Circle{ℝ}, v, x, y) = (v .= sym_rem(y - x))
 function log(M::Circle{ℂ}, x::Number, y::Number)
     cosθ = complex_dot(x, y)
     if cosθ ≈ -1  # appr. opposing points, return deterministic choice from set-valued log
@@ -224,6 +224,8 @@ function log(M::Circle{ℂ}, x::Number, y::Number)
     end
     return project_tangent(M, x, v)
 end
+
+log!(::Circle{ℝ}, v, x, y) = (v .= sym_rem(y - x))
 function log!(M::Circle{ℂ}, v, x, y)
     cosθ = complex_dot(x, y)
     if cosθ ≈ -1
@@ -293,9 +295,9 @@ retract(M::Circle, x, y, m::ExponentialRetraction) = exp(M, x, y)
 
 representation_size(::Circle) = (1,)
 
-sharp!(M::Circle, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
-
 sharp(M::Circle, x::Number, w::CoTFVector) = FVector(TangentSpace, w.data)
+
+sharp!(M::Circle, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 @doc doc"""
     sym_rem(x,[T=π])
@@ -340,6 +342,7 @@ function vector_transport_to(
     end
     return vto
 end
+
 vector_transport_to!(::Circle{ℝ}, w, x, v, y, ::ParallelTransport) = (w .= v)
 function vector_transport_to!(M::Circle{ℂ}, vto, x, v, y, ::ParallelTransport)
     v_xy = log(M, x, y)
@@ -355,6 +358,7 @@ end
 function vector_transport_along(M::Circle, x::Number, v::Number, c)
     return vector_transport_along!(M, zero(v), x, v, c)
 end
+
 function vector_transport_direction(
     M::Circle,
     x::Number,
@@ -367,4 +371,5 @@ function vector_transport_direction(
 end
 
 zero_tangent_vector(::Circle, x::Number) = zero(x)
+
 zero_tangent_vector!(::Circle, v, x) = fill!(v, 0)

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -256,7 +256,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` on the
 mean modulo 2π.
 """
 mean(::Circle, ::Any)
-mean(::Circle,x::Array{<:Real}; kwargs...) = sym_rem(sum(x))
+mean(::Circle, x::Array{<:Real}; kwargs...) = sym_rem(sum(x))
 mean(::Circle, x::Array{<:Real}, w::AbstractVector; kwargs...) = sym_rem(sum(w .* x))
 
 @inline norm(::Circle, x, v) = sum(abs, v)

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -116,8 +116,7 @@ function exp!(M::Circle{ℂ}, y, x, v)
 end
 
 function flat!(::Circle, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 flat(M::Circle, x::Number, w::FVector{TangentSpaceType}) = FVector(CotangentSpace, w.data)
 
@@ -296,8 +295,7 @@ retract(M::Circle, x, y, m::ExponentialRetraction) = exp(M, x, y)
 representation_size(::Circle) = (1,)
 
 function sharp!(M::Circle, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpace, w.data)
 

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -293,7 +293,7 @@ project_tangent!(::Circle{ℂ}, w, x, v) = (w .= v - complex_dot(x, v) * x)
 retract(M::Circle, x, y) = retract(M, x, y, ExponentialRetraction())
 retract(M::Circle, x, y, m::ExponentialRetraction) = exp(M, x, y)
 
-representation_size(::Circle) = (1,)
+@generated representation_size(::Circle) = (1,)
 
 sharp(M::Circle, x::Number, w::CoTFVector) = FVector(TangentSpace, w.data)
 

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -196,10 +196,12 @@ inner(::Circle, ::Any...)
 @inline inner(::Circle{ℝ}, x::Real, w::Real, v::Real) = v * w
 @inline inner(::Circle{ℂ}, x, w, v) = complex_dot(w, v)
 
-inverse_retract(M::Circle, x::Number, y::Number) =
-    inverse_retract(M, x, y, LogarithmicInverseRetraction())
-inverse_retract(M::Circle, x::Number, y::Number, ::LogarithmicInverseRetraction) =
-    log(M, x, y)
+function inverse_retract(M::Circle, x::Number, y::Number)
+    return inverse_retract(M, x, y, LogarithmicInverseRetraction())
+end
+function inverse_retract(M::Circle, x::Number, y::Number, ::LogarithmicInverseRetraction)
+    return log(M, x, y)
+end
 
 @doc doc"""
     log(M::Circle, x, y)
@@ -312,8 +314,9 @@ sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpa
 Compute symmetric remainder of `x` with respect to the interall 2*`T`, i.e.
 `(x+T)%2T`, where the default for `T` is $\pi$
 """
-sym_rem(x::N, T = π) where {N<:Number} =
-    (x ≈ T ? convert(N, -T) : rem(x, convert(N, 2 * T), RoundNearest))
+function sym_rem(x::N, T = π) where {N<:Number}
+    return (x ≈ T ? convert(N, -T) : rem(x, convert(N, 2 * T), RoundNearest))
+end
 sym_rem(x, T = π) where {N} = sym_rem.(x, Ref(T))
 
 @doc doc"""
@@ -360,8 +363,9 @@ function vector_transport_to!(M::Circle{ℂ}, vto, x, v, y, ::ParallelTransport)
     return vto
 end
 
-vector_transport_along(M::Circle, x::Number, v::Number, c) =
-    vector_transport_along!(M, zero(v), x, v, c)
+function vector_transport_along(M::Circle, x::Number, v::Number, c)
+    return vector_transport_along!(M, zero(v), x, v, c)
+end
 function vector_transport_direction(
     M::Circle,
     x::Number,

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -127,9 +127,7 @@ function get_basis(M::Circle{ℝ}, x, B::DiagonalizingOrthonormalBasis)
     return PrecomputedDiagonalizingOrthonormalBasis(vs, @SVector [0])
 end
 
-function get_coordinates(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis)
-    return v
-end
+get_coordinates(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis) = v
 
 function get_coordinates(M::Circle{ℝ}, x, v, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
@@ -147,9 +145,7 @@ function get_coordinates(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
     return @SVector [w]
 end
 
-function get_vector(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis)
-    return v
-end
+get_vector(M::Circle{ℝ}, x, v, B::ArbitraryOrthonormalBasis) = v
 
 function get_vector(M::Circle{ℝ}, x, v, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
@@ -161,9 +157,7 @@ end
 
 Return tangent vector from the coordinate in the Lie algebra of the circle.
 """
-function get_vector(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis)
-    return @SVector [1im * v[1] * x[1]]
-end
+get_vector(M::Circle{ℂ}, x, v, B::ArbitraryOrthonormalBasis) = @SVector [1im * v[1] * x[1]]
 
 @doc doc"""
     injectivity_radius(M::Circle[, x])
@@ -243,8 +237,7 @@ function log!(M::Circle{ℂ}, v, x, y)
         θ = acos(cosθ)
         v .= (y - cosθ * x) / usinc(θ)
     end
-    project_tangent!(M, v, x, v)
-    return v
+    return project_tangent!(M, v, x, v)
 end
 
 @doc doc"""
@@ -378,7 +371,4 @@ function vector_transport_direction(
 end
 
 zero_tangent_vector(::Circle, x::Number) = zero(x)
-function zero_tangent_vector!(::Circle, v, x)
-    fill!(v, 0)
-    return v
-end
+zero_tangent_vector!(::Circle, v, x) = fill!(v, 0)

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -12,8 +12,8 @@ Generate the `ℝ`-valued Circle represented by angles, which
 alternatively can be set to use the [`AbstractNumbers`](@ref) `f=ℂ` to obtain the `Circle`
 represented by `ℂ`-valued `Circle` of unit numbers.
 """
-struct Circle{F} <: Manifold where {F <: AbstractNumbers} end
-Circle(f::AbstractNumbers=ℝ) = Circle{f}()
+struct Circle{F} <: Manifold where {F<:AbstractNumbers} end
+Circle(f::AbstractNumbers = ℝ) = Circle{f}()
 
 @doc doc"""
     check_manifold_point(M::Circle, x)
@@ -23,16 +23,21 @@ For the real-valued case, `x` is an angle and hence it checks that $x \in [-\pi,
 for the complex-valued case its a unit number, $x \in \mathbb C$ with $\lvert x \rvert = 1$.
 """
 check_manifold_point(::Circle, ::Any...)
-function check_manifold_point(M::Circle{ℝ},x; kwargs...)
-    if !isapprox(sym_rem(x),x;kwargs...)
-        return DomainError(x,"The point $(x) does not lie on $(M), since its is not in [-π,π).")
+function check_manifold_point(M::Circle{ℝ}, x; kwargs...)
+    if !isapprox(sym_rem(x), x; kwargs...)
+        return DomainError(
+            x,
+            "The point $(x) does not lie on $(M), since its is not in [-π,π).",
+        )
     end
     return nothing
 end
-function check_manifold_point(M::Circle{ℂ},x; kwargs...)
-    if !isapprox(sum(abs.(x)), 1.; kwargs...)
-        return DomainError(abs(x),
-        "The point $(x) does not lie on the $(M) since its norm is not 1.")
+function check_manifold_point(M::Circle{ℂ}, x; kwargs...)
+    if !isapprox(sum(abs.(x)), 1.0; kwargs...)
+        return DomainError(
+            abs(x),
+            "The point $(x) does not lie on the $(M) since its norm is not 1.",
+        )
     end
     return nothing
 end
@@ -48,15 +53,16 @@ in the complex plane, i.e. the inner product is zero.
 """
 check_tangent_vector(::Circle{ℝ}, ::Any...; ::Any...)
 function check_tangent_vector(M::Circle{ℝ}, x, v; kwargs...)
-    perr = check_manifold_point(M,x)
+    perr = check_manifold_point(M, x)
     return perr # if x is valid all v that are real numbers are valid
 end
-function check_tangent_vector(M::Circle{ℂ},x,v; kwargs...)
-    perr = check_manifold_point(M,x)
+function check_tangent_vector(M::Circle{ℂ}, x, v; kwargs...)
+    perr = check_manifold_point(M, x)
     perr === nothing || return perr
-    if !isapprox( abs(complex_dot(x,v)), 0.; kwargs...)
-        return DomainError(abs(complex_dot(x,v)),
-            "The value $(v) is not a tangent vector to $(x) on $(M), since it is not orthogonal in the embedding."
+    if !isapprox(abs(complex_dot(x, v)), 0.0; kwargs...)
+        return DomainError(
+            abs(complex_dot(x, v)),
+            "The value $(v) is not a tangent vector to $(x) on $(M), since it is not orthogonal in the embedding.",
         )
     end
     return nothing
@@ -68,7 +74,7 @@ end
 Compute the inner product of two (complex) numbers with in the complex plane.
 """
 complex_dot(a, b) = dot(map(real, a), map(real, b)) + dot(map(imag, a), map(imag, b))
-complex_dot(a::Number,b::Number) = (real(a)*real(b) + imag(a)*imag(b))
+complex_dot(a::Number, b::Number) = (real(a) * real(b) + imag(a) * imag(b))
 
 @doc doc"""
     distance(M::Circle, x, y)
@@ -79,8 +85,8 @@ case and the angle between both complex numbers in the Gaussian plane for the
 complex-valued case.
 """
 distance(::Circle, ::Any...)
-distance(::Circle{ℝ}, x::Real, y::Real) = abs(sym_rem(x-y))
-distance(::Circle{ℝ}, x, y) = abs(sum(sym_rem.(x-y)))
+distance(::Circle{ℝ}, x::Real, y::Real) = abs(sym_rem(x - y))
+distance(::Circle{ℝ}, x, y) = abs(sum(sym_rem.(x - y)))
 distance(::Circle{ℂ}, x, y) = acos(clamp(complex_dot(x, y), -1, 1))
 
 @doc doc"""
@@ -97,15 +103,15 @@ For the complex-valued case the formula is the same as for the [`Sphere`](@ref)
 applied to valuedin the complex plane.
 """
 exp(::Circle, ::Any...)
-exp(::Circle{ℝ}, x::Real, v::Real) = sym_rem(x+v)
-exp!(::Circle{ℝ}, y, x, v) = (y .= sym_rem(x+v))
+exp(::Circle{ℝ}, x::Real, v::Real) = sym_rem(x + v)
+exp!(::Circle{ℝ}, y, x, v) = (y .= sym_rem(x + v))
 function exp(M::Circle{ℂ}, x::Number, v::Number)
     θ = norm(M, x, v)
-    return cos(θ)*x + usinc(θ)*v
+    return cos(θ) * x + usinc(θ) * v
 end
 function exp!(M::Circle{ℂ}, y, x, v)
     θ = norm(M, x, v)
-    y .= cos(θ)*x + usinc(θ)*v
+    y .= cos(θ) * x + usinc(θ) * v
     return y
 end
 
@@ -113,7 +119,7 @@ function flat!(::Circle, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSp
     copyto!(v.data, w.data)
     return v
 end
-flat(M::Circle, x::Number, w::FVector{TangentSpaceType}) = FVector(CotangentSpace,w.data)
+flat(M::Circle, x::Number, w::FVector{TangentSpaceType}) = FVector(CotangentSpace, w.data)
 
 function get_basis(M::Circle{ℝ}, x, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
@@ -186,12 +192,14 @@ g_x(v,w) = v^\mathrm{T}w
 for the complex case interpreting complex numbers in the Gaussian plane.
 """
 inner(::Circle, ::Any...)
-@inline inner(::Circle{ℝ}, x, w, v) = dot(v,w)
-@inline inner(::Circle{ℝ}, x::Real, w::Real, v::Real) = v*w
+@inline inner(::Circle{ℝ}, x, w, v) = dot(v, w)
+@inline inner(::Circle{ℝ}, x::Real, w::Real, v::Real) = v * w
 @inline inner(::Circle{ℂ}, x, w, v) = complex_dot(w, v)
 
-inverse_retract(M::Circle, x::Number, y::Number) = inverse_retract(M, x, y, LogarithmicInverseRetraction())
-inverse_retract(M::Circle, x::Number, y::Number, ::LogarithmicInverseRetraction) = log(M,x,y)
+inverse_retract(M::Circle, x::Number, y::Number) =
+    inverse_retract(M, x, y, LogarithmicInverseRetraction())
+inverse_retract(M::Circle, x::Number, y::Number, ::LogarithmicInverseRetraction) =
+    log(M, x, y)
 
 @doc doc"""
     log(M::Circle, x, y)
@@ -207,31 +215,31 @@ For the complex-valued case the formula is the same as for the [`Sphere`](@ref)
 applied to valuedin the complex plane.
 """
 log(::Circle, ::Any...)
-log(::Circle{ℝ}, x::Real, y::Real) = sym_rem(y-x)
-log!(::Circle{ℝ}, v, x, y) = (v .= sym_rem(y-x))
+log(::Circle{ℝ}, x::Real, y::Real) = sym_rem(y - x)
+log!(::Circle{ℝ}, v, x, y) = (v .= sym_rem(y - x))
 function log(M::Circle{ℂ}, x::Number, y::Number)
     cosθ = complex_dot(x, y)
     if cosθ ≈ -1  # appr. opposing points, return deterministic choice from set-valued log
-        v = real(x) ≈ 1 ? 1im : 1+0im
-        v = v - complex_dot(x, v)* x
+        v = real(x) ≈ 1 ? 1im : 1 + 0im
+        v = v - complex_dot(x, v) * x
         v *= π / norm(v)
     else
         cosθ = cosθ > 1 ? one(cosθ) : cosθ
         θ = acos(cosθ)
-        v = (y - cosθ*x)/usinc(θ)
+        v = (y - cosθ * x) / usinc(θ)
     end
     return project_tangent(M, x, v)
 end
 function log!(M::Circle{ℂ}, v, x, y)
     cosθ = complex_dot(x, y)
     if cosθ ≈ -1
-        v .= sum(real.(x)) ≈ 1 ? 1.0im : 1.0+0.0im
-        v .= v - complex_dot(x, v)* x
+        v .= sum(real.(x)) ≈ 1 ? 1.0im : 1.0 + 0.0im
+        v .= v - complex_dot(x, v) * x
         v .*= π / norm(v)
     else
         cosθ = cosθ > 1 ? one(cosθ) : cosθ
         θ = acos(cosθ)
-        v .= (y - cosθ*x)/usinc(θ)
+        v .= (y - cosθ * x) / usinc(θ)
     end
     project_tangent!(M, v, x, v)
     return v
@@ -253,7 +261,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` on the
 mean modulo 2π.
 """
 mean(::Circle, ::Any)
-mean(::Circle,x::Array{<:Real},w::AbstractVector; kwargs...) = sym_rem(sum(w.*x))
+mean(::Circle, x::Array{<:Real}, w::AbstractVector; kwargs...) = sym_rem(sum(w .* x))
 
 @inline norm(::Circle, x, v) = sum(abs, v)
 
@@ -267,10 +275,10 @@ complex plane.
 """
 project_point(::Circle, ::Any)
 project_point(::Circle{ℝ}, x::Real) = sym_rem(x)
-project_point(::Circle{ℂ}, x::Number) = x/abs(x)
+project_point(::Circle{ℂ}, x::Number) = x / abs(x)
 
 project_point!(::Circle{ℝ}, x) = (x .= sym_rem(x))
-project_point!(::Circle{ℂ}, x) = (x .= x/sum(abs.(x)))
+project_point!(::Circle{ℂ}, x) = (x .= x / sum(abs.(x)))
 
 @doc doc"""
     project_tangent(M::Circle, x, v)
@@ -282,13 +290,13 @@ For the complex valued case `v` is projected onto the line in the complex plane
 that is parallel to the tangent to `x` on the unit circle and contains `0`.
 """
 project_tangent(::Circle{ℝ}, x::Real, v::Real) = v
-project_tangent(::Circle{ℂ}, x::Number, v::Number) = v - complex_dot(x,v)*x
+project_tangent(::Circle{ℂ}, x::Number, v::Number) = v - complex_dot(x, v) * x
 
 project_tangent!(::Circle{ℝ}, w, x, v) = (w .= v)
-project_tangent!(::Circle{ℂ}, w, x, v) = (w .= v - complex_dot(x,v)*x)
+project_tangent!(::Circle{ℂ}, w, x, v) = (w .= v - complex_dot(x, v) * x)
 
-retract(M::Circle,x,y) = retract(M, x, y, ExponentialRetraction())
-retract(M::Circle,x,y,m::ExponentialRetraction) = exp(M,x,y)
+retract(M::Circle, x, y) = retract(M, x, y, ExponentialRetraction())
+retract(M::Circle, x, y, m::ExponentialRetraction) = exp(M, x, y)
 
 representation_size(::Circle) = (1,)
 
@@ -296,7 +304,7 @@ function sharp!(M::Circle, v::FVector{TangentSpaceType}, x, w::FVector{Cotangent
     copyto!(v.data, w.data)
     return v
 end
-sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpace,w.data)
+sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpace, w.data)
 
 @doc doc"""
     sym_rem(x,[T=π])
@@ -304,8 +312,9 @@ sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpa
 Compute symmetric remainder of `x` with respect to the interall 2*`T`, i.e.
 `(x+T)%2T`, where the default for `T` is $\pi$
 """
-sym_rem(x::N, T=π) where {N<:Number} = (x≈T ? convert(N,-T) : rem(x, convert(N,2*T),RoundNearest))
-sym_rem(x, T=π) where N = sym_rem.(x, Ref(T))
+sym_rem(x::N, T = π) where {N<:Number} =
+    (x ≈ T ? convert(N, -T) : rem(x, convert(N, 2 * T), RoundNearest))
+sym_rem(x, T = π) where {N} = sym_rem.(x, Ref(T))
 
 @doc doc"""
     vector_transport_to(M::Circle, x, v, y, ::ParallelTransport)
@@ -323,13 +332,19 @@ where [`log`](@ref) denotes the logarithmic map on `M`.
 """
 vector_transport_to(::Circle, ::Any, ::Any, ::Any, ::ParallelTransport)
 vector_transport_to(::Circle{ℝ}, x::Real, v::Real, y::Real, ::ParallelTransport) = v
-function vector_transport_to(M::Circle{ℂ}, x::Number, v::Number, y::Number, ::ParallelTransport)
+function vector_transport_to(
+    M::Circle{ℂ},
+    x::Number,
+    v::Number,
+    y::Number,
+    ::ParallelTransport,
+)
     v_xy = log(M, x, y)
     vl = norm(M, x, v_xy)
     vto = v
     if vl > 0
-        factor = 2*complex_dot(v, y)/(abs(x + y)^2)
-        vto -= factor.*(x + y)
+        factor = 2 * complex_dot(v, y) / (abs(x + y)^2)
+        vto -= factor .* (x + y)
     end
     return vto
 end
@@ -339,19 +354,26 @@ function vector_transport_to!(M::Circle{ℂ}, vto, x, v, y, ::ParallelTransport)
     vl = norm(M, x, v_xy)
     vto .= v
     if vl > 0
-        factor = 2*complex_dot(v, y)/(sum(abs.(x + y).^2))
-        vto .-= factor.*(x + y)
+        factor = 2 * complex_dot(v, y) / (sum(abs.(x + y) .^ 2))
+        vto .-= factor .* (x + y)
     end
     return vto
 end
 
-vector_transport_along(M::Circle,x::Number,v::Number,c) = vector_transport_along!(M,zero(v),x,v,c)
-function vector_transport_direction(M::Circle,x::Number,v::Number,vdir::Number,m::AbstractVectorTransportMethod)
+vector_transport_along(M::Circle, x::Number, v::Number, c) =
+    vector_transport_along!(M, zero(v), x, v, c)
+function vector_transport_direction(
+    M::Circle,
+    x::Number,
+    v::Number,
+    vdir::Number,
+    m::AbstractVectorTransportMethod,
+)
     y = exp(M, x, vdir)
     return vector_transport_to(M, x, v, y, m)
 end
 
-zero_tangent_vector(::Circle,x::Number) = zero(x)
+zero_tangent_vector(::Circle, x::Number) = zero(x)
 function zero_tangent_vector!(::Circle, v, x)
     fill!(v, 0)
     return v

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -115,10 +115,9 @@ function exp!(M::Circle{ℂ}, y, x, v)
     return y
 end
 
-function flat!(::Circle, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
-    return copyto!(v, w)
-end
-flat(M::Circle, x::Number, w::FVector{TangentSpaceType}) = FVector(CotangentSpace, w.data)
+flat!(::Circle, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
+
+flat(M::Circle, x::Number, w::TFVector) = FVector(CotangentSpace, w.data)
 
 function get_basis(M::Circle{ℝ}, x, B::DiagonalizingOrthonormalBasis)
     sbv = sign(B.v[1])
@@ -294,10 +293,9 @@ retract(M::Circle, x, y, m::ExponentialRetraction) = exp(M, x, y)
 
 representation_size(::Circle) = (1,)
 
-function sharp!(M::Circle, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
-    return copyto!(v, w)
-end
-sharp(M::Circle, x::Number, w::FVector{CotangentSpaceType}) = FVector(TangentSpace, w.data)
+sharp!(M::Circle, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
+
+sharp(M::Circle, x::Number, w::CoTFVector) = FVector(TangentSpace, w.data)
 
 @doc doc"""
     sym_rem(x,[T=π])

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -276,10 +276,7 @@ Project an arbitrary vector `v` into the tangent space of a point `x` on the
 space of `M` can be identified with all of `M`.
 """
 project_tangent(::Euclidean, ::Any...)
-function project_tangent!(M::Euclidean, w, x, v)
-    w .= v
-    return w
-end
+project_tangent!(M::Euclidean, w, x, v) = copyto!(w, v)
 
 """
     projected_distribution(M::Euclidean, d, [x])
@@ -327,10 +324,7 @@ Parallely transport the vector `v` from the tangent space at `x` to the tangent 
 on the [`Euclidean`](@ref) `M`, which simplifies to the identity.
 """
 vector_transport_to(::Euclidean, ::Any, ::Any, ::Any, ::ParallelTransport)
-function vector_transport_to!(M::Euclidean, vto, x, v, y, ::ParallelTransport)
-    vto .= v
-    return vto
-end
+vector_transport_to!(M::Euclidean, vto, x, v, y, ::ParallelTransport) = copyto!(vto, v)
 
 var(::Euclidean, x::AbstractVector; kwargs...) = sum(var(x; kwargs...))
 function var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T}
@@ -349,7 +343,4 @@ Return the zero vector in the tangent space of `x` on the [`Euclidean`](@ref)
 """
 zero_tangent_vector(::Euclidean, ::Any...)
 
-function zero_tangent_vector!(M::Euclidean, v, x)
-    fill!(v, 0)
-    return v
-end
+zero_tangent_vector!(M::Euclidean, v, x) = fill!(v, 0)

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -76,8 +76,7 @@ function flat!(
     x,
     w::FVector{TangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 function get_basis(M::Euclidean{<:Tuple,ℝ}, x, B::ArbitraryOrthonormalBasis)
@@ -313,8 +312,7 @@ function sharp!(
     x,
     w::FVector{CotangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 """

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -22,8 +22,9 @@ The default `field=ℝ` can also be set to `field=ℂ`.
 The dimension of this space is $k \dim_ℝ 𝔽$, where $\dim_ℝ 𝔽$ is the
 [`real_dimension`](@ref) of the field $𝔽$.
 """
-struct Euclidean{N<:Tuple,T} <: Manifold where {N, T<: AbstractNumbers} end
-Euclidean(n::Vararg{Int,N};field::AbstractNumbers=ℝ) where N = Euclidean{Tuple{n...},field}()
+struct Euclidean{N<:Tuple,T} <: Manifold where {N,T<:AbstractNumbers} end
+Euclidean(n::Vararg{Int,N}; field::AbstractNumbers = ℝ) where {N} =
+    Euclidean{Tuple{n...},field}()
 
 """
     EuclideanMetric <: RiemannianMetric
@@ -70,20 +71,25 @@ Transform a tangent vector into a cotangent. Since they can directly be identifi
 [`Euclidean`](@ref) case, this yields just the identity for a tangent vector `w` in the
 tangent space of `x` on `M`. The result is returned also in place in `v`.
 """
-flat(::Euclidean,::Any...)
-function flat!(M::Euclidean, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
+flat(::Euclidean, ::Any...)
+function flat!(
+    M::Euclidean,
+    v::FVector{CotangentSpaceType},
+    x,
+    w::FVector{TangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
 
-function get_basis(M::Euclidean{<:Tuple, ℝ}, x, B::ArbitraryOrthonormalBasis)
+function get_basis(M::Euclidean{<:Tuple,ℝ}, x, B::ArbitraryOrthonormalBasis)
     vecs = [_euclidean_basis_vector(x, i) for i in eachindex(x)]
     return PrecomputedOrthonormalBasis(vecs)
 end
 
-function get_basis(M::Euclidean{<:Tuple, ℂ}, x, B::ArbitraryOrthonormalBasis)
+function get_basis(M::Euclidean{<:Tuple,ℂ}, x, B::ArbitraryOrthonormalBasis)
     vecs = [_euclidean_basis_vector(x, i) for i in eachindex(x)]
-    return PrecomputedOrthonormalBasis([vecs; im*vecs])
+    return PrecomputedOrthonormalBasis([vecs; im * vecs])
 end
 
 function get_basis(M::Euclidean, x, B::DiagonalizingOrthonormalBasis)
@@ -92,27 +98,27 @@ function get_basis(M::Euclidean, x, B::DiagonalizingOrthonormalBasis)
     return PrecomputedDiagonalizingOrthonormalBasis(vecs, kappas)
 end
 
-function get_coordinates(M::Euclidean{<:Tuple, ℝ}, x, v, B::ArbitraryOrDiagonalizingBasis)
+function get_coordinates(M::Euclidean{<:Tuple,ℝ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     PS = prod(S)
     return reshape(v, PS)
 end
 
-function get_coordinates(M::Euclidean{<:Tuple, ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
+function get_coordinates(M::Euclidean{<:Tuple,ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     PS = prod(S)
     return [reshape(real(v), PS); reshape(imag(v), PS)]
 end
 
-function get_vector(M::Euclidean{<:Tuple, ℝ}, x, v, B::ArbitraryOrDiagonalizingBasis)
+function get_vector(M::Euclidean{<:Tuple,ℝ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     return reshape(v, S)
 end
 
-function get_vector(M::Euclidean{<:Tuple, ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
+function get_vector(M::Euclidean{<:Tuple,ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     N = div(length(v), 2)
-    return reshape(v[1:N] + im*v[N+1:end], S)
+    return reshape(v[1:N] + im * v[N+1:end], S)
 end
 function hat(M::Euclidean{N,ℝ}, x, vⁱ) where {N}
     return reshape(vⁱ, representation_size(TangentBundleFibers(M)))
@@ -152,9 +158,10 @@ inner(::Euclidean, ::Any...)
 
 inverse_local_metric(M::MetricManifold{<:Manifold,EuclideanMetric}, x) = local_metric(M, x)
 
-is_default_metric(::Euclidean,::EuclideanMetric) = Val(true)
+is_default_metric(::Euclidean, ::EuclideanMetric) = Val(true)
 
-local_metric(::MetricManifold{<:Manifold,EuclideanMetric}, x) = Diagonal(ones(SVector{size(x, 1),eltype(x)}))
+local_metric(::MetricManifold{<:Manifold,EuclideanMetric}, x) =
+    Diagonal(ones(SVector{size(x, 1),eltype(x)}))
 
 @doc doc"""
     log(M::Euclidean, x, y)
@@ -183,7 +190,8 @@ function manifold_dimension(M::Euclidean{N,𝔽}) where {N,𝔽}
 end
 
 mean(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs...) = mean(x)
-mean(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) = mean(x, w)
+mean(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) =
+    mean(x, w)
 mean(::Euclidean, x::AbstractVector; kwargs...) = mean(x)
 mean!(M::Euclidean, y, x::AbstractVector, w::AbstractVector; kwargs...) =
     mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
@@ -208,8 +216,10 @@ mean_and_var(M::Euclidean, x::AbstractVector, w::AbstractWeights; kwargs...) =
     mean_and_var(M, x, w, GeodesicInterpolation(); kwargs...)
 
 median(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs...) = median(x)
-median(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) = median(x, w)
-median!(::Euclidean{Tuple{1}}, y, x::AbstractVector; kwargs...) = copyto!(y, [median(vcat(x...))])
+median(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) =
+    median(x, w)
+median!(::Euclidean{Tuple{1}}, y, x::AbstractVector; kwargs...) =
+    copyto!(y, [median(vcat(x...))])
 median!(::Euclidean{Tuple{1}}, y, x::AbstractVector, w::AbstractWeights; kwargs...) =
     copyto!(y, [median(vcat(x...), w)])
 
@@ -229,7 +239,7 @@ norm(::MetricManifold{<:Manifold,EuclideanMetric}, x, v) = norm(v)
 Normal distribution in ambient space with standard deviation `σ`
 projected to tangent space at `x`.
 """
-function normal_tvector_distribution(M::Euclidean{Tuple{N}}, x, σ) where N
+function normal_tvector_distribution(M::Euclidean{Tuple{N}}, x, σ) where {N}
     d = Distributions.MvNormal(zero(x), σ)
     return ProjectedFVectorDistribution(TangentBundleFibers(M), x, d, project_vector!, x)
 end
@@ -284,8 +294,13 @@ since cotangent and tangent vectors can directly be identified in the [`Euclidea
 case, this yields just the identity for a cotangent vector `w` in the tangent space
 of `x` on `M`.
 """
-sharp(::Euclidean,::Any...)
-function sharp!(M::Euclidean, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
+sharp(::Euclidean, ::Any...)
+function sharp!(
+    M::Euclidean,
+    v::FVector{TangentSpaceType},
+    x,
+    w::FVector{CotangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
@@ -303,7 +318,8 @@ function vector_transport_to!(M::Euclidean, vto, x, v, y, ::ParallelTransport)
 end
 
 var(::Euclidean, x::AbstractVector; kwargs...) = sum(var(x; kwargs...))
-var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T} = sum(var(x; mean=m, kwargs...))
+var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T} =
+    sum(var(x; mean = m, kwargs...))
 
 vee!(::Euclidean{N,ℝ}, vⁱ, x, v) where {N} = copyto!(vⁱ, v)
 

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -1,6 +1,3 @@
-import LinearAlgebra: norm
-using StatsBase: AbstractWeights
-
 @doc doc"""
     Euclidean{T<:Tuple} <: Manifold
 

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -70,14 +70,7 @@ Transform a tangent vector into a cotangent. Since they can directly be identifi
 tangent space of `x` on `M`. The result is returned also in place in `v`.
 """
 flat(::Euclidean, ::Any...)
-function flat!(
-    M::Euclidean,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
-    return copyto!(v, w)
-end
+flat!(M::Euclidean, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_basis(M::Euclidean{<:Tuple,ℝ}, x, B::ArbitraryOrthonormalBasis)
     vecs = [_euclidean_basis_vector(x, i) for i in eachindex(x)]
@@ -306,14 +299,7 @@ case, this yields just the identity for a cotangent vector `w` in the tangent sp
 of `x` on `M`.
 """
 sharp(::Euclidean, ::Any...)
-function sharp!(
-    M::Euclidean,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
-    return copyto!(v, w)
-end
+sharp!(M::Euclidean, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 """
     vector_transport_to(M::Euclidean, x, v, y, ::ParallelTransport)

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -23,8 +23,9 @@ The dimension of this space is $k \dim_ℝ 𝔽$, where $\dim_ℝ 𝔽$ is the
 [`real_dimension`](@ref) of the field $𝔽$.
 """
 struct Euclidean{N<:Tuple,T} <: Manifold where {N,T<:AbstractNumbers} end
-Euclidean(n::Vararg{Int,N}; field::AbstractNumbers = ℝ) where {N} =
-    Euclidean{Tuple{n...},field}()
+function Euclidean(n::Vararg{Int,N}; field::AbstractNumbers = ℝ) where {N}
+    return Euclidean{Tuple{n...},field}()
+end
 
 """
     EuclideanMetric <: RiemannianMetric
@@ -160,8 +161,9 @@ inverse_local_metric(M::MetricManifold{<:Manifold,EuclideanMetric}, x) = local_m
 
 is_default_metric(::Euclidean, ::EuclideanMetric) = Val(true)
 
-local_metric(::MetricManifold{<:Manifold,EuclideanMetric}, x) =
-    Diagonal(ones(SVector{size(x, 1),eltype(x)}))
+function local_metric(::MetricManifold{<:Manifold,EuclideanMetric}, x)
+    return Diagonal(ones(SVector{size(x, 1),eltype(x)}))
+end
 
 @doc doc"""
     log(M::Euclidean, x, y)
@@ -190,11 +192,18 @@ function manifold_dimension(M::Euclidean{N,𝔽}) where {N,𝔽}
 end
 
 mean(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs...) = mean(x)
-mean(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) =
-    mean(x, w)
+function mean(
+    ::Euclidean{Tuple{1}},
+    x::AbstractVector{<:Number},
+    w::AbstractWeights;
+    kwargs...,
+)
+    return mean(x, w)
+end
 mean(::Euclidean, x::AbstractVector; kwargs...) = mean(x)
-mean!(M::Euclidean, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
+function mean!(M::Euclidean, y, x::AbstractVector, w::AbstractVector; kwargs...)
+    return mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
+end
 
 function mean_and_var(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs...)
     m, v = mean_and_var(x; kwargs...)
@@ -212,16 +221,25 @@ function mean_and_var(
     return m, sum(v)
 end
 
-mean_and_var(M::Euclidean, x::AbstractVector, w::AbstractWeights; kwargs...) =
-    mean_and_var(M, x, w, GeodesicInterpolation(); kwargs...)
+function mean_and_var(M::Euclidean, x::AbstractVector, w::AbstractWeights; kwargs...)
+    return mean_and_var(M, x, w, GeodesicInterpolation(); kwargs...)
+end
 
 median(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs...) = median(x)
-median(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}, w::AbstractWeights; kwargs...) =
-    median(x, w)
-median!(::Euclidean{Tuple{1}}, y, x::AbstractVector; kwargs...) =
-    copyto!(y, [median(vcat(x...))])
-median!(::Euclidean{Tuple{1}}, y, x::AbstractVector, w::AbstractWeights; kwargs...) =
-    copyto!(y, [median(vcat(x...), w)])
+function median(
+    ::Euclidean{Tuple{1}},
+    x::AbstractVector{<:Number},
+    w::AbstractWeights;
+    kwargs...,
+)
+    return median(x, w)
+end
+function median!(::Euclidean{Tuple{1}}, y, x::AbstractVector; kwargs...)
+    return copyto!(y, [median(vcat(x...))])
+end
+function median!(::Euclidean{Tuple{1}}, y, x::AbstractVector, w::AbstractWeights; kwargs...)
+    return copyto!(y, [median(vcat(x...), w)])
+end
 
 @doc doc"""
     norm(M::Euclidean, x, v)
@@ -318,8 +336,9 @@ function vector_transport_to!(M::Euclidean, vto, x, v, y, ::ParallelTransport)
 end
 
 var(::Euclidean, x::AbstractVector; kwargs...) = sum(var(x; kwargs...))
-var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T} =
-    sum(var(x; mean = m, kwargs...))
+function var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T}
+    return sum(var(x; mean = m, kwargs...))
+end
 
 vee!(::Euclidean{N,ℝ}, vⁱ, x, v) where {N} = copyto!(vⁱ, v)
 

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -293,7 +293,7 @@ end
 Return the array dimensions required to represent an element on the
 [`Euclidean`](@ref) `M`, i.e. the vector of all array dimensions.
 """
-representation_size(::Euclidean{N}) where {N} = size_to_tuple(N)
+@generated representation_size(::Euclidean{N}) where {N} = size_to_tuple(N)
 
 """
     sharp(M::Euclidean, x, w)

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -20,6 +20,7 @@ The dimension of this space is $k \dim_ℝ 𝔽$, where $\dim_ℝ 𝔽$ is the
 [`real_dimension`](@ref) of the field $𝔽$.
 """
 struct Euclidean{N<:Tuple,T} <: Manifold where {N,T<:AbstractNumbers} end
+
 function Euclidean(n::Vararg{Int,N}; field::AbstractNumbers = ℝ) where {N}
     return Euclidean{Tuple{n...},field}()
 end
@@ -60,6 +61,7 @@ Compute the exponential map on the [`Euclidean`](@ref) manifold `M` from `x` in 
 ````
 """
 exp(::Euclidean, ::Any...)
+
 exp!(M::Euclidean, y, x, v) = (y .= x .+ v)
 
 """
@@ -70,18 +72,17 @@ Transform a tangent vector into a cotangent. Since they can directly be identifi
 tangent space of `x` on `M`. The result is returned also in place in `v`.
 """
 flat(::Euclidean, ::Any...)
+
 flat!(M::Euclidean, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_basis(M::Euclidean{<:Tuple,ℝ}, x, B::ArbitraryOrthonormalBasis)
     vecs = [_euclidean_basis_vector(x, i) for i in eachindex(x)]
     return PrecomputedOrthonormalBasis(vecs)
 end
-
 function get_basis(M::Euclidean{<:Tuple,ℂ}, x, B::ArbitraryOrthonormalBasis)
     vecs = [_euclidean_basis_vector(x, i) for i in eachindex(x)]
     return PrecomputedOrthonormalBasis([vecs; im * vecs])
 end
-
 function get_basis(M::Euclidean, x, B::DiagonalizingOrthonormalBasis)
     vecs = get_basis(M, x, ArbitraryOrthonormalBasis()).vectors
     kappas = zeros(real(eltype(x)), manifold_dimension(M))
@@ -93,7 +94,6 @@ function get_coordinates(M::Euclidean{<:Tuple,ℝ}, x, v, B::ArbitraryOrDiagonal
     PS = prod(S)
     return reshape(v, PS)
 end
-
 function get_coordinates(M::Euclidean{<:Tuple,ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     PS = prod(S)
@@ -104,12 +104,12 @@ function get_vector(M::Euclidean{<:Tuple,ℝ}, x, v, B::ArbitraryOrDiagonalizing
     S = representation_size(M)
     return reshape(v, S)
 end
-
 function get_vector(M::Euclidean{<:Tuple,ℂ}, x, v, B::ArbitraryOrDiagonalizingBasis)
     S = representation_size(M)
     N = div(length(v), 2)
     return reshape(v[1:N] + im * v[N+1:end], S)
 end
+
 function hat(M::Euclidean{N,ℝ}, x, vⁱ) where {N}
     return reshape(vⁱ, representation_size(TangentBundleFibers(M)))
 end
@@ -163,6 +163,8 @@ which in this case is just
 \log_x y = y - x.
 ````
 """
+log(::Euclidean, ::Any...)
+
 log!(M::Euclidean, v, x, y) = (v .= y .- x)
 
 log_local_metric_density(M::MetricManifold{<:Manifold,EuclideanMetric}, x) = zero(eltype(x))
@@ -190,6 +192,7 @@ function mean(
     return mean(x, w)
 end
 mean(::Euclidean, x::AbstractVector; kwargs...) = mean(x)
+
 function mean!(M::Euclidean, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
 end
@@ -198,7 +201,6 @@ function mean_and_var(::Euclidean{Tuple{1}}, x::AbstractVector{<:Number}; kwargs
     m, v = mean_and_var(x; kwargs...)
     return m, sum(v)
 end
-
 function mean_and_var(
     ::Euclidean{Tuple{1}},
     x::AbstractVector{<:Number},
@@ -209,7 +211,6 @@ function mean_and_var(
     m, v = mean_and_var(x, w; corrected = corrected, kwargs...)
     return m, sum(v)
 end
-
 function mean_and_var(M::Euclidean, x::AbstractVector, w::AbstractWeights; kwargs...)
     return mean_and_var(M, x, w, GeodesicInterpolation(); kwargs...)
 end
@@ -223,6 +224,7 @@ function median(
 )
     return median(x, w)
 end
+
 function median!(::Euclidean{Tuple{1}}, y, x::AbstractVector; kwargs...)
     return copyto!(y, [median(vcat(x...))])
 end
@@ -258,6 +260,7 @@ Project an arbitrary point `x` onto the [`Euclidean`](@ref) `M`, which
 is of course just the identity map.
 """
 project_point(::Euclidean, ::Any...)
+
 project_point!(M::Euclidean, x) = x
 
 """
@@ -268,6 +271,7 @@ Project an arbitrary vector `v` into the tangent space of a point `x` on the
 space of `M` can be identified with all of `M`.
 """
 project_tangent(::Euclidean, ::Any...)
+
 project_tangent!(M::Euclidean, w, x, v) = copyto!(w, v)
 
 """
@@ -299,6 +303,7 @@ case, this yields just the identity for a cotangent vector `w` in the tangent sp
 of `x` on `M`.
 """
 sharp(::Euclidean, ::Any...)
+
 sharp!(M::Euclidean, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 """
@@ -308,6 +313,7 @@ Parallely transport the vector `v` from the tangent space at `x` to the tangent 
 on the [`Euclidean`](@ref) `M`, which simplifies to the identity.
 """
 vector_transport_to(::Euclidean, ::Any, ::Any, ::Any, ::ParallelTransport)
+
 vector_transport_to!(M::Euclidean, vto, x, v, y, ::ParallelTransport) = copyto!(vto, v)
 
 var(::Euclidean, x::AbstractVector; kwargs...) = sum(var(x; kwargs...))
@@ -315,9 +321,9 @@ function var(::Euclidean, x::AbstractVector{T}, m::T; kwargs...) where {T}
     return sum(var(x; mean = m, kwargs...))
 end
 
-vee!(::Euclidean{N,ℝ}, vⁱ, x, v) where {N} = copyto!(vⁱ, v)
-
 vee(::Euclidean{N,ℝ}, x, v) where {N} = vec(v)
+
+vee!(::Euclidean{N,ℝ}, vⁱ, x, v) where {N} = copyto!(vⁱ, v)
 
 """
     zero_tangent_vector(M::Euclidean, x)

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -253,6 +253,7 @@ Section 3 in [^Vandereycken2013].
     > arXiv: [1209.3834](https://arxiv.org/abs/1209.3834).
 """
 project_tangent(::FixedRankMatrices, ::Any...)
+
 function project_tangent!(
     ::FixedRankMatrices,
     vto::UMVTVector,
@@ -296,6 +297,7 @@ in the sense that $S_k$ is the diagonal matrix of size $k\times k$ with the $k$ 
 singular values and $U$ and $V$ are shortened accordingly.
 """
 retract(::FixedRankMatrices, ::Any, ::Any, ::PolarRetraction)
+
 function retract!(
     ::FixedRankMatrices{M,N,k},
     y::SVDMPoint,
@@ -363,6 +365,7 @@ function zero_tangent_vector(::FixedRankMatrices{m,n,k}, x::SVDMPoint) where {m,
     )
     return v
 end
+
 function zero_tangent_vector!(
     ::FixedRankMatrices{m,n,k},
     v::UMVTVector,

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -172,9 +172,7 @@ function check_tangent_vector(
     kwargs...,
 ) where {m,n,k}
     c = check_manifold_point(M, x)
-    if c !== nothing
-        return c
-    end
+    c === nothing || return c
     if (size(v.U) != (m, k)) || (size(v.Vt) != (k, n)) || (size(v.M) != (k, k))
         return DomainError(
             cat(size(v.U), size(v.M), size(v.Vt), dims = 1),
@@ -341,11 +339,13 @@ function copyto!(x::SVDMPoint, y::SVDMPoint)
     copyto!(x.U, y.U)
     copyto!(x.S, y.S)
     copyto!(x.Vt, y.Vt)
+    return x
 end
 function copyto!(v::UMVTVector, w::UMVTVector)
     copyto!(v.U, w.U)
     copyto!(v.M, w.M)
     copyto!(v.Vt, w.Vt)
+    return v
 end
 
 @doc doc"""

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -44,7 +44,8 @@ Generate the manifold of `m`-by-`n` real-valued matrices of rank `k`.
     > arXiv: [1209.3834](https://arxiv.org/abs/1209.3834).
 """
 struct FixedRankMatrices{M,N,K,T} <: Manifold end
-FixedRankMatrices(m::Int, n::Int, k::Int, t::AbstractNumbers=ℝ) = FixedRankMatrices{m,n,k,t}()
+FixedRankMatrices(m::Int, n::Int, k::Int, t::AbstractNumbers = ℝ) =
+    FixedRankMatrices{m,n,k,t}()
 
 @doc doc"""
     SVDMPoint <: MPoint
@@ -65,17 +66,17 @@ and accordingly shortened $U$ (columns) and $V^\mathrm{T}$ (rows)
 * `SVDMPoint(U,S,Vt,k)` for the svd factors to initialize the `SVDMPoint`,
   stores its svd factors shortened to the best rank $k$ approximation
 """
-struct SVDMPoint{TU<:AbstractMatrix, TS<:AbstractVector, TVt<:AbstractMatrix} <: MPoint
+struct SVDMPoint{TU<:AbstractMatrix,TS<:AbstractVector,TVt<:AbstractMatrix} <: MPoint
     U::TU
     S::TS
     Vt::TVt
 end
 SVDMPoint(A::AbstractMatrix) = SVDMPoint(svd(A))
-SVDMPoint(S::SVD) = SVDMPoint(S.U,S.S,S.Vt)
-SVDMPoint(A::Matrix,k::Int) = SVDMPoint(svd(A),k)
-SVDMPoint(S::SVD,k::Int) = SVDMPoint(S.U,S.S,S.Vt,k)
-SVDMPoint(U,S,Vt,k::Int) = SVDMPoint(U[:,1:k],S[1:k],Vt[1:k,:])
-==(x::SVDMPoint, y::SVDMPoint) = (x.U==y.U) && (x.S==y.S) && (x.Vt==y.Vt)
+SVDMPoint(S::SVD) = SVDMPoint(S.U, S.S, S.Vt)
+SVDMPoint(A::Matrix, k::Int) = SVDMPoint(svd(A), k)
+SVDMPoint(S::SVD, k::Int) = SVDMPoint(S.U, S.S, S.Vt, k)
+SVDMPoint(U, S, Vt, k::Int) = SVDMPoint(U[:, 1:k], S[1:k], Vt[1:k, :])
+==(x::SVDMPoint, y::SVDMPoint) = (x.U == y.U) && (x.S == y.S) && (x.Vt == y.Vt)
 
 @doc doc"""
     UMVTVector <: TVector
@@ -88,24 +89,24 @@ together with its base point, see for example [`FixedRankMatrices`](@ref)
 * `UMVTVector(U,M,Vt,k)` store the umv factors after shortening them down to
   inner dimensions $k$, i.e. in $UMV^\mathrm{T}$, $M\in\mathbb R^{k\times k}$
 """
-struct UMVTVector{TU<:AbstractMatrix, TM<:AbstractMatrix, TVt<:AbstractMatrix} <: TVector
+struct UMVTVector{TU<:AbstractMatrix,TM<:AbstractMatrix,TVt<:AbstractMatrix} <: TVector
     U::TU
     M::TM
     Vt::TVt
 end
 
-UMVTVector(U,M,Vt,k::Int) = UMVTVector(U[:,1:k],M[1:k,1:k],Vt[1:k,:])
+UMVTVector(U, M, Vt, k::Int) = UMVTVector(U[:, 1:k], M[1:k, 1:k], Vt[1:k, :])
 
 # here the division in M corrects for the first factor in UMV + x.U*Vt + U*x.Vt, where x is the base point to v.
-*(v::UMVTVector, s::Number) = UMVTVector(v.U*s, v.M*s,  v.Vt*s)
-*(s::Number, v::UMVTVector) = UMVTVector(s*v.U, s*v.M, s*v.Vt)
-/(v::UMVTVector, s::Number) = UMVTVector(v.U/s, v.M/s, v.Vt/s)
-\(s::Number, v::UMVTVector) = UMVTVector(s\v.U, s\v.M, s\v.Vt)
+*(v::UMVTVector, s::Number) = UMVTVector(v.U * s, v.M * s, v.Vt * s)
+*(s::Number, v::UMVTVector) = UMVTVector(s * v.U, s * v.M, s * v.Vt)
+/(v::UMVTVector, s::Number) = UMVTVector(v.U / s, v.M / s, v.Vt / s)
+\(s::Number, v::UMVTVector) = UMVTVector(s \ v.U, s \ v.M, s \ v.Vt)
 +(v::UMVTVector, w::UMVTVector) = UMVTVector(v.U + w.U, v.M + w.M, v.Vt + w.Vt)
 -(v::UMVTVector, w::UMVTVector) = UMVTVector(v.U - w.U, v.M - w.M, v.Vt - w.Vt)
 -(v::UMVTVector) = UMVTVector(-v.U, -v.M, -v.Vt)
 +(v::UMVTVector) = UMVTVector(v.U, v.M, v.Vt)
-==(v::UMVTVector,w::UMVTVector) = (v.U==w.U) && (v.M==w.M) && (v.Vt==w.Vt)
+==(v::UMVTVector, w::UMVTVector) = (v.U == w.U) && (v.M == w.M) && (v.Vt == w.Vt)
 @doc doc"""
     check_manifold_point(M::FixedRankMatrices{m,n,k},x; kwargs...)
 
@@ -114,27 +115,43 @@ Check whether the matrix or [`SVDMPoint`](@ref) `x` ids a valid point on the
 rank `k`. For the [`SVDMPoint`](@ref) the internal representation also has to have the right
 shape, i.e. `x.U` and `x.Vt` have to be unitary.
 """
-function check_manifold_point(M::FixedRankMatrices{m,n,k},x; kwargs...) where {m,n,k}
+function check_manifold_point(M::FixedRankMatrices{m,n,k}, x; kwargs...) where {m,n,k}
     r = rank(x; kwargs...)
     s = "The point $(x) does not lie on the manifold of fixed rank matrices of size ($(m),$(n)) witk rank $(k), "
-    if size(x) != (m,n)
-        return DomainError(size(x), string(s,"since its size is wrong."))
+    if size(x) != (m, n)
+        return DomainError(size(x), string(s, "since its size is wrong."))
     end
     if r > k
         return DomainError(r, string(s, "since its rank is too large ($(r))."))
     end
     return nothing
 end
-function check_manifold_point(F::FixedRankMatrices{m,n,k}, x::SVDMPoint; kwargs...) where {m,n,k}
+function check_manifold_point(
+    F::FixedRankMatrices{m,n,k},
+    x::SVDMPoint;
+    kwargs...,
+) where {m,n,k}
     s = "The point $(x) does not lie on the manifold of fixed rank matrices of size ($(m),$(n)) witk rank $(k), "
-    if (size(x.U) != (m,k)) || (length(x.S) != k) || (size(x.Vt) != (k,n))
-        return DomainError([size(x.U)...,length(x.S),size(x.Vt)...], string(s, "since the dimensions do not fit (expected $(n)x$(m) rank $(k) got $(size(x.U,1))x$(size(x.Vt,2)) rank $(size(x.S))."))
+    if (size(x.U) != (m, k)) || (length(x.S) != k) || (size(x.Vt) != (k, n))
+        return DomainError(
+            [size(x.U)..., length(x.S), size(x.Vt)...],
+            string(
+                s,
+                "since the dimensions do not fit (expected $(n)x$(m) rank $(k) got $(size(x.U,1))x$(size(x.Vt,2)) rank $(size(x.S)).",
+            ),
+        )
     end
-    if !isapprox(x.U'*x.U,one(zeros(n,n)); kwargs...)
-        return DomainError(norm(x.U'*x.U-one(zeros(n,n))), string(s," since U is not orthonormal/unitary."))
+    if !isapprox(x.U' * x.U, one(zeros(n, n)); kwargs...)
+        return DomainError(
+            norm(x.U' * x.U - one(zeros(n, n))),
+            string(s, " since U is not orthonormal/unitary."),
+        )
     end
-    if !isapprox(x.Vt'*x.Vt, one(zeros(n,n)); kwargs...)
-        return DomainError(norm(x.Vt'*x.Vt-one(zeros(n,n))), string(s," since V is not orthonormal/unitary."))
+    if !isapprox(x.Vt' * x.Vt, one(zeros(n, n)); kwargs...)
+        return DomainError(
+            norm(x.Vt' * x.Vt - one(zeros(n, n))),
+            string(s, " since V is not orthonormal/unitary."),
+        )
     end
     return nothing
 end
@@ -148,19 +165,33 @@ the [`SVDMPoint`](@ref) `x` on the [`FixedRankMatrices`](@ref) `M`, i.e. that
 and its dimensions are consistent with `x` and `M`, i.e. correspond to `m`-by-`n`
 matrices of rank `k`.
 """
-function check_tangent_vector(M::FixedRankMatrices{m,n,k}, x::SVDMPoint, v::UMVTVector; kwargs...) where {m,n,k}
-    c = check_manifold_point(M,x)
+function check_tangent_vector(
+    M::FixedRankMatrices{m,n,k},
+    x::SVDMPoint,
+    v::UMVTVector;
+    kwargs...,
+) where {m,n,k}
+    c = check_manifold_point(M, x)
     if c !== nothing
         return c
     end
-    if (size(v.U) != (m,k)) || (size(v.Vt) != (k,n)) || (size(v.M) != (k,k))
-        return DomainError(cat(size(v.U),size(v.M),size(v.Vt),dims=1), "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since the matrix dimensions to not fit (expected $(m)x$(k), $(k)x$(k), $(k)x$(n)).")
+    if (size(v.U) != (m, k)) || (size(v.Vt) != (k, n)) || (size(v.M) != (k, k))
+        return DomainError(
+            cat(size(v.U), size(v.M), size(v.Vt), dims = 1),
+            "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since the matrix dimensions to not fit (expected $(m)x$(k), $(k)x$(k), $(k)x$(n)).",
+        )
     end
-    if !isapprox(v.U'*x.U, zeros(k,k); kwargs...)
-        return DomainError(norm(v.U'*x.U-zeros(k,k)), "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since v.U'x.U is not zero. ")
+    if !isapprox(v.U' * x.U, zeros(k, k); kwargs...)
+        return DomainError(
+            norm(v.U' * x.U - zeros(k, k)),
+            "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since v.U'x.U is not zero. ",
+        )
     end
-    if !isapprox(v.Vt*x.Vt', zeros(k,k); kwargs...)
-        return DomainError(norm(v.Vt*x.Vt-zeros(k,k)), "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since v.V'x.V is not zero.")
+    if !isapprox(v.Vt * x.Vt', zeros(k, k); kwargs...)
+        return DomainError(
+            norm(v.Vt * x.Vt - zeros(k, k)),
+            "The tangent vector $(v) is not a tangent vector to $(x) on the fixed rank matrices since v.V'x.V is not zero.",
+        )
     end
 end
 
@@ -172,11 +203,17 @@ Compute the inner product of `v` and `w` in the tangent space of `x` on the
 using `dot` on the elements (`U`, `Vt`, `M`) of `v` and `w`.
 """
 function inner(::FixedRankMatrices, x::SVDMPoint, v::UMVTVector, w::UMVTVector)
-    return dot(v.U,w.U) + dot(v.M,w.M) + dot(v.Vt,w.Vt)
+    return dot(v.U, w.U) + dot(v.M, w.M) + dot(v.Vt, w.Vt)
 end
 
-isapprox(::FixedRankMatrices, x::SVDMPoint, y::SVDMPoint; kwargs...) = isapprox( x.U*Diagonal(x.S)*x.Vt, y.U*Diagonal(y.S)*y.Vt; kwargs...)
-isapprox(::FixedRankMatrices, x::SVDMPoint, v::UMVTVector, w::UMVTVector; kwargs...) = isapprox(x.U*v.M*x.Vt + v.U*x.Vt + x.U*v.Vt, x.U*w.M*x.Vt + w.U*x.Vt + x.U*w.Vt; kwargs...)
+isapprox(::FixedRankMatrices, x::SVDMPoint, y::SVDMPoint; kwargs...) =
+    isapprox(x.U * Diagonal(x.S) * x.Vt, y.U * Diagonal(y.S) * y.Vt; kwargs...)
+isapprox(::FixedRankMatrices, x::SVDMPoint, v::UMVTVector, w::UMVTVector; kwargs...) =
+    isapprox(
+        x.U * v.M * x.Vt + v.U * x.Vt + x.U * v.Vt,
+        x.U * w.M * x.Vt + w.U * x.Vt + x.U * w.Vt;
+        kwargs...,
+    )
 
 @doc doc"""
     manifold_dimension(M::FixedRankMatrices{m,n,k,𝔽})
@@ -191,7 +228,7 @@ k(m + n - k) \dim_ℝ 𝔽,
 where $\dim_ℝ 𝔽$ is the [`real_dimension`](@ref) of `𝔽`.
 """
 function manifold_dimension(::FixedRankMatrices{m,n,k,𝔽}) where {m,n,k,𝔽}
-    return (m + n - k)*k*real_dimension(𝔽)
+    return (m + n - k) * k * real_dimension(𝔽)
 end
 
 @doc doc"""
@@ -209,23 +246,28 @@ Section 3 in [^Vandereycken2013].
     > doi: [10.1137/110845768](https://doi.org/10.1137/110845768),
     > arXiv: [1209.3834](https://arxiv.org/abs/1209.3834).
 """
-project_tangent(::FixedRankMatrices,::Any...)
+project_tangent(::FixedRankMatrices, ::Any...)
 function project_tangent!(
     ::FixedRankMatrices,
     vto::UMVTVector,
     x::SVDMPoint,
-    A::AbstractMatrix
+    A::AbstractMatrix,
 )
-    av = A*(x.Vt')
-    uTav = x.U'*av
-    aTu = A'*x.U
+    av = A * (x.Vt')
+    uTav = x.U' * av
+    aTu = A' * x.U
     vto.M .= uTav
-    vto.U .= A * x.Vt' - x.U*uTav
-    vto.Vt .= (aTu - x.Vt'*uTav')'
+    vto.U .= A * x.Vt' - x.U * uTav
+    vto.Vt .= (aTu - x.Vt' * uTav')'
     return vto
 end
-function project_tangent!(M::FixedRankMatrices, vto::UMVTVector, x::SVDMPoint, v::UMVTVector)
-    return project_tangent!(M,vto,x, v.U * v.M * v.Vt)
+function project_tangent!(
+    M::FixedRankMatrices,
+    vto::UMVTVector,
+    x::SVDMPoint,
+    v::UMVTVector,
+)
+    return project_tangent!(M, vto, x, v.U * v.M * v.Vt)
 end
 
 @doc doc"""
@@ -234,7 +276,7 @@ end
 Return the element size of a point on the [`FixedRankMatrices`](@ref) `M`, i.e.
 the size of matrices on this manifold $(m,n)$.
 """
-representation_size(M::FixedRankMatrices{m, n}) where {m,n} = (m,n)
+representation_size(M::FixedRankMatrices{m,n}) where {m,n} = (m, n)
 
 @doc doc"""
     retract(M, x, v, ::PolarRetraction)
@@ -248,24 +290,42 @@ in the sense that $S_k$ is the diagonal matrix of size $k\times k$ with the $k$ 
 singular values and $U$ and $V$ are shortened accordingly.
 """
 retract(::FixedRankMatrices, ::Any, ::Any, ::PolarRetraction)
-function retract!(::FixedRankMatrices{M,N,k}, y::SVDMPoint, x::SVDMPoint, v::UMVTVector, ::PolarRetraction) where {M,N,k}
-    s = svd( x.U * Diagonal(x.S) * x.Vt + (x.U * v.M * x.Vt + v.U*x.Vt + v.U*v.Vt) )
-    y.U .= s.U[:,1:k]
+function retract!(
+    ::FixedRankMatrices{M,N,k},
+    y::SVDMPoint,
+    x::SVDMPoint,
+    v::UMVTVector,
+    ::PolarRetraction,
+) where {M,N,k}
+    s = svd(x.U * Diagonal(x.S) * x.Vt + (x.U * v.M * x.Vt + v.U * x.Vt + v.U * v.Vt))
+    y.U .= s.U[:, 1:k]
     y.S .= s.S[1:k]
-    y.Vt .= s.Vt[1:k,:]
+    y.Vt .= s.Vt[1:k, :]
     return y
 end
 
 similar(x::SVDMPoint) = SVDMPoint(similar(x.U), similar(x.S), similar(x.Vt))
-similar(x::SVDMPoint, ::Type{T}) where T = SVDMPoint(similar(x.U,T), similar(x.S,T), similar(x.Vt,T))
+similar(x::SVDMPoint, ::Type{T}) where {T} =
+    SVDMPoint(similar(x.U, T), similar(x.S, T), similar(x.Vt, T))
 similar(v::UMVTVector) = UMVTVector(similar(v.U), similar(v.M), similar(v.Vt))
-similar(v::UMVTVector, ::Type{T}) where T = UMVTVector(similar(v.U,T), similar(v.M,T), similar(v.Vt,T))
+similar(v::UMVTVector, ::Type{T}) where {T} =
+    UMVTVector(similar(v.U, T), similar(v.M, T), similar(v.Vt, T))
 
 eltype(x::SVDMPoint) = typeof(one(eltype(x.U)) + one(eltype(x.S)) + one(eltype(x.Vt)))
 eltype(v::UMVTVector) = typeof(one(eltype(v.U)) + one(eltype(v.M)) + one(eltype(v.Vt)))
 
-one(x::SVDMPoint) = SVDMPoint(one(zeros(size(x.U,1),size(x.U,1))), ones(length(x.S)), one(zeros(size(x.Vt,2),size(x.Vt,2))), length(x.S))
-one(v::UMVTVector) = UMVTVector(one(zeros(size(v.U,1),size(v.U,1))), one(zeros(size(v.M))), one(zeros(size(v.Vt,2),size(v.Vt,2))), size(v.M,1))
+one(x::SVDMPoint) = SVDMPoint(
+    one(zeros(size(x.U, 1), size(x.U, 1))),
+    ones(length(x.S)),
+    one(zeros(size(x.Vt, 2), size(x.Vt, 2))),
+    length(x.S),
+)
+one(v::UMVTVector) = UMVTVector(
+    one(zeros(size(v.U, 1), size(v.U, 1))),
+    one(zeros(size(v.M))),
+    one(zeros(size(v.Vt, 2), size(v.Vt, 2))),
+    size(v.M, 1),
+)
 
 function copyto!(x::SVDMPoint, y::SVDMPoint)
     copyto!(x.U, y.U)
@@ -286,12 +346,20 @@ Return a [`UMVTVector`](@ref) representing the zero tangent vector in the tangen
 structure are zero matrices.
 """
 function zero_tangent_vector(::FixedRankMatrices{m,n,k}, x::SVDMPoint) where {m,n,k}
-    v = UMVTVector( zeros(eltype(x.U),m,k), zeros(eltype(x.S),k,k), zeros(eltype(x.Vt),k,n) )
+    v = UMVTVector(
+        zeros(eltype(x.U), m, k),
+        zeros(eltype(x.S), k, k),
+        zeros(eltype(x.Vt), k, n),
+    )
     return v
 end
-function zero_tangent_vector!(::FixedRankMatrices{m,n,k}, v::UMVTVector, x::SVDMPoint) where {m,n,k}
-    v.U .= zeros(eltype(v.U),m,k)
-    v.M .= zeros(eltype(v.M),k,k)
-    v.Vt .= zeros(eltype(v.Vt),k,n)
+function zero_tangent_vector!(
+    ::FixedRankMatrices{m,n,k},
+    v::UMVTVector,
+    x::SVDMPoint,
+) where {m,n,k}
+    v.U .= zeros(eltype(v.U), m, k)
+    v.M .= zeros(eltype(v.M), k, k)
+    v.Vt .= zeros(eltype(v.Vt), k, n)
     return v
 end

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra: diag, Diagonal, svd, SVD, rank, dot
-import Base: \, /, +, -, *, ==, similar, one, copyto!
 @doc doc"""
     FixedRankMatrices{m,n,k,T} <: Manifold
 

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -283,7 +283,7 @@ end
 Return the element size of a point on the [`FixedRankMatrices`](@ref) `M`, i.e.
 the size of matrices on this manifold $(m,n)$.
 """
-representation_size(M::FixedRankMatrices{m,n}) where {m,n} = (m, n)
+@generated representation_size(::FixedRankMatrices{m,n}) where {m,n} = (m, n)
 
 @doc doc"""
     retract(M, x, v, ::PolarRetraction)

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -44,8 +44,9 @@ Generate the manifold of `m`-by-`n` real-valued matrices of rank `k`.
     > arXiv: [1209.3834](https://arxiv.org/abs/1209.3834).
 """
 struct FixedRankMatrices{M,N,K,T} <: Manifold end
-FixedRankMatrices(m::Int, n::Int, k::Int, t::AbstractNumbers = ℝ) =
-    FixedRankMatrices{m,n,k,t}()
+function FixedRankMatrices(m::Int, n::Int, k::Int, t::AbstractNumbers = ℝ)
+    return FixedRankMatrices{m,n,k,t}()
+end
 
 @doc doc"""
     SVDMPoint <: MPoint
@@ -107,6 +108,7 @@ UMVTVector(U, M, Vt, k::Int) = UMVTVector(U[:, 1:k], M[1:k, 1:k], Vt[1:k, :])
 -(v::UMVTVector) = UMVTVector(-v.U, -v.M, -v.Vt)
 +(v::UMVTVector) = UMVTVector(v.U, v.M, v.Vt)
 ==(v::UMVTVector, w::UMVTVector) = (v.U == w.U) && (v.M == w.M) && (v.Vt == w.Vt)
+
 @doc doc"""
     check_manifold_point(M::FixedRankMatrices{m,n,k},x; kwargs...)
 
@@ -206,14 +208,22 @@ function inner(::FixedRankMatrices, x::SVDMPoint, v::UMVTVector, w::UMVTVector)
     return dot(v.U, w.U) + dot(v.M, w.M) + dot(v.Vt, w.Vt)
 end
 
-isapprox(::FixedRankMatrices, x::SVDMPoint, y::SVDMPoint; kwargs...) =
-    isapprox(x.U * Diagonal(x.S) * x.Vt, y.U * Diagonal(y.S) * y.Vt; kwargs...)
-isapprox(::FixedRankMatrices, x::SVDMPoint, v::UMVTVector, w::UMVTVector; kwargs...) =
-    isapprox(
+function isapprox(::FixedRankMatrices, x::SVDMPoint, y::SVDMPoint; kwargs...)
+    return isapprox(x.U * Diagonal(x.S) * x.Vt, y.U * Diagonal(y.S) * y.Vt; kwargs...)
+end
+function isapprox(
+    ::FixedRankMatrices,
+    x::SVDMPoint,
+    v::UMVTVector,
+    w::UMVTVector;
+    kwargs...,
+)
+    return isapprox(
         x.U * v.M * x.Vt + v.U * x.Vt + x.U * v.Vt,
         x.U * w.M * x.Vt + w.U * x.Vt + x.U * w.Vt;
         kwargs...,
     )
+end
 
 @doc doc"""
     manifold_dimension(M::FixedRankMatrices{m,n,k,𝔽})
@@ -305,11 +315,13 @@ function retract!(
 end
 
 similar(x::SVDMPoint) = SVDMPoint(similar(x.U), similar(x.S), similar(x.Vt))
-similar(x::SVDMPoint, ::Type{T}) where {T} =
-    SVDMPoint(similar(x.U, T), similar(x.S, T), similar(x.Vt, T))
+function similar(x::SVDMPoint, ::Type{T}) where {T}
+    return SVDMPoint(similar(x.U, T), similar(x.S, T), similar(x.Vt, T))
+end
 similar(v::UMVTVector) = UMVTVector(similar(v.U), similar(v.M), similar(v.Vt))
-similar(v::UMVTVector, ::Type{T}) where {T} =
-    UMVTVector(similar(v.U, T), similar(v.M, T), similar(v.Vt, T))
+function similar(v::UMVTVector, ::Type{T}) where {T}
+    return UMVTVector(similar(v.U, T), similar(v.M, T), similar(v.Vt, T))
+end
 
 eltype(x::SVDMPoint) = typeof(one(eltype(x.U)) + one(eltype(x.S)) + one(eltype(x.Vt)))
 eltype(v::UMVTVector) = typeof(one(eltype(v.U)) + one(eltype(v.M)) + one(eltype(v.Vt)))

--- a/src/manifolds/GraphManifold.jl
+++ b/src/manifolds/GraphManifold.jl
@@ -1,8 +1,3 @@
-
-using LightGraphs
-import LightGraphs: AbstractSimpleGraph, is_directed
-import SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
-
 @doc doc"""
     GraphManifoldType
 
@@ -35,84 +30,113 @@ of a graph `G` depending on the [`GraphManifoldType`](@ref) `T`.
 * `G` is an `AbstractSimpleGraph`
 * `M` is a [`Manifold`](@ref)
 """
-struct GraphManifold{G<:AbstractGraph, TM, T<:GraphManifoldType} <: AbstractPowerManifold{TM}
+struct GraphManifold{G<:AbstractGraph,TM,T<:GraphManifoldType} <: AbstractPowerManifold{TM}
     graph::G
     manifold::TM
 end
-GraphManifold(g::G,M::TM,::VertexManifold) where {G<:AbstractGraph, TM <: Manifold} = GraphManifold{G,TM,VertexManifold}(g,M)
-GraphManifold(g::G,M::TM,::EdgeManifold) where {G<:AbstractGraph, TM <: Manifold} = GraphManifold{G,TM,EdgeManifold}(g,M)
+
+function GraphManifold(g::G, M::TM, ::VertexManifold) where {G<:AbstractGraph,TM<:Manifold}
+    return GraphManifold{G,TM,VertexManifold}(g, M)
+end
+function GraphManifold(g::G, M::TM, ::EdgeManifold) where {G<:AbstractGraph,TM<:Manifold}
+    return GraphManifold{G,TM,EdgeManifold}(g, M)
+end
 
 @doc doc"""
     check_manifold_point(M::GraphManifold,x)
 
-check whether `x` is a valid point on the [`GraphManifold`](@ref), i.e. its
+Check whether `x` is a valid point on the [`GraphManifold`](@ref), i.e. its
 length equals the number of vertices (for [`VertexManifold`](@ref)s) or
 the number of edges (for [`EdgeManifold`](@ref)s) and that each element of `x`
 passes the [`check_manifold_point`](@ref) test for the base manifold `M.manifold`.
 """
-check_manifold_point(::GraphManifold,::Any...)
+check_manifold_point(::GraphManifold, ::Any...)
 function check_manifold_point(
     M::GraphManifold{G,TM,VertexManifold},
     x;
-    kwargs...) where {G <: AbstractGraph, TM <: Manifold}
+    kwargs...,
+) where {G<:AbstractGraph,TM<:Manifold}
     if size(x)[end] != nv(M.graph)
-        return DomainError(length(x), "The number of points in `x` ($(size(x)[end])) does not match the number of nodes in the graph ($(nv(M.graph))).")
+        return DomainError(
+            length(x),
+            "The number of points in `x` ($(size(x)[end])) does not match the number of nodes in the graph ($(nv(M.graph))).",
+        )
     end
-    return check_manifold_point(PowerManifold(M.manifold,nv(M.graph)), x; kwargs...)
+    return check_manifold_point(PowerManifold(M.manifold, nv(M.graph)), x; kwargs...)
 end
 function check_manifold_point(
     M::GraphManifold{G,TM,EdgeManifold},
     x;
-    kwargs...) where {G <: AbstractGraph,TM<:Manifold}
+    kwargs...,
+) where {G<:AbstractGraph,TM<:Manifold}
     if size(x)[end] != ne(M.graph)
-        return DomainError(length(x), "The number of points in `x` ($(size(x)[end])) does not match the number of edges in the graph ($(ne(M.graph))).")
+        return DomainError(
+            length(x),
+            "The number of points in `x` ($(size(x)[end])) does not match the number of edges in the graph ($(ne(M.graph))).",
+        )
     end
-    return check_manifold_point(PowerManifold(M.manifold,ne(M.graph)), x; kwargs...)
+    return check_manifold_point(PowerManifold(M.manifold, ne(M.graph)), x; kwargs...)
 end
 
 @doc doc"""
     check_tangent_vector(M::GraphManifold,x,v)
 
-check whether `x` is a valid point on the [`GraphManifold`](@ref), and
+Check whether `x` is a valid point on the [`GraphManifold`](@ref), and
 `v` it from its tangent space, i.e. its
 length equals the number of vertices (for [`VertexManifold`](@ref)s) or
 the number of edges (for [`EdgeManifold`](@ref)s) and that each element of `v`
 together with its corresponding einty of `x` passes the
 [`check_tangent_vector`](@ref) test for the base manifold `M.manifold`.
 """
-check_tangent_vector(::GraphManifold,::Any...)
+check_tangent_vector(::GraphManifold, ::Any...)
 function check_tangent_vector(
-    M::GraphManifold{<: AbstractGraph, <: Manifold, VertexManifold}, x, v; kwargs...)
+    M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold},
+    x,
+    v;
+    kwargs...,
+)
     if size(x)[end] != nv(M.graph)
-        return DomainError(length(x), "The number of points in `x` ($(size(x)[end]) does not match the number of nodes in the graph ($(nv(M.graph))).")
+        return DomainError(
+            length(x),
+            "The number of points in `x` ($(size(x)[end]) does not match the number of nodes in the graph ($(nv(M.graph))).",
+        )
     end
     if size(v)[end] != nv(M.graph)
-        return DomainError(length(v), "The number of points in `v` ($(size(v)[end]) does not match the number of nodes in the graph ($(nv(M.graph))).")
+        return DomainError(
+            length(v),
+            "The number of points in `v` ($(size(v)[end]) does not match the number of nodes in the graph ($(nv(M.graph))).",
+        )
     end
-    return check_tangent_vector(PowerManifold(M.manifold,nv(M.graph)), x, v; kwargs...)
+    return check_tangent_vector(PowerManifold(M.manifold, nv(M.graph)), x, v; kwargs...)
 end
 function check_tangent_vector(
-    M::GraphManifold{<: AbstractGraph, <: Manifold, EdgeManifold}, x, v; kwargs...)
+    M::GraphManifold{<:AbstractGraph,<:Manifold,EdgeManifold},
+    x,
+    v;
+    kwargs...,
+)
     if size(x)[end] != ne(M.graph)
-        return DomainError(length(x), "The number of elements in `x` ($(size(x)[end]) does not match the number of edges in the graph ($(ne(M.graph))).")
+        return DomainError(
+            length(x),
+            "The number of elements in `x` ($(size(x)[end]) does not match the number of edges in the graph ($(ne(M.graph))).",
+        )
     end
     if size(v)[end] != ne(M.graph)
-        return DomainError(length(v), "The number of elements in `v` ($(size(v)[end]) does not match the number of edges in the graph ($(ne(M.graph))).")
+        return DomainError(
+            length(v),
+            "The number of elements in `v` ($(size(v)[end]) does not match the number of edges in the graph ($(ne(M.graph))).",
+        )
     end
-    return check_tangent_vector(PowerManifold(M.manifold,ne(M.graph)), x, v; kwargs...)
+    return check_tangent_vector(PowerManifold(M.manifold, ne(M.graph)), x, v; kwargs...)
 end
 
-function get_iterator(M::GraphManifold{<: AbstractGraph, <:Manifold, EdgeManifold})
-    return 1:ne(M.graph)
-end
-function get_iterator(M::GraphManifold{<: AbstractGraph, <:Manifold, VertexManifold})
-    return 1:nv(M.graph)
-end
+get_iterator(M::GraphManifold{<:AbstractGraph,<:Manifold,EdgeManifold}) = 1:ne(M.graph)
+get_iterator(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold}) = 1:nv(M.graph)
 
 @doc doc"""
     incident_log(M::GraphManifold, x)
 
-return the tangent vector on the (vertex) [`GraphManifold`](@ref), where at
+Return the tangent vector on the (vertex) [`GraphManifold`](@ref), where at
 each node the sum of the [`log`](@ref)s to incident nodes is computed.
 For a `SimpleGraph`, an egde is interpreted as double edge in the corresponding
 SimpleDiGraph
@@ -120,29 +144,42 @@ SimpleDiGraph
 If the internal graph is a `SimpleWeightedGraph` the weighted sum of the
 tangent vectors is computed.
 """
-function incident_log(M::GraphManifold{<:AbstractGraph, <:Manifold,  VertexManifold}, x)
-    v = zero_tangent_vector(M,x)
+function incident_log(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold}, x)
+    v = zero_tangent_vector(M, x)
     return incident_log!(M, v, x)
 end
-function incident_log!(M::GraphManifold{<:AbstractGraph, <:Manifold,  VertexManifold}, v, x)
+
+function incident_log!(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold}, v, x)
     rep_size = representation_size(M.manifold)
     rsC = rep_size_to_colons(rep_size)
     for e in edges(M.graph)
         vw = _write(rep_size, v, src(e))
-        v[rsC..., src(e)] += log(M.manifold, _read(rep_size, x, src(e)), _read(rep_size, x, dst(e)) )
+        v[rsC..., src(e)] +=
+            log(M.manifold, _read(rep_size, x, src(e)), _read(rep_size, x, dst(e)))
         if !is_directed(M.graph)
-            v[rsC...,dst(e)] += log(M.manifold, _read(rep_size, x, dst(e)), _read(rep_size, x, src(e)) )
+            v[rsC..., dst(e)] +=
+                log(M.manifold, _read(rep_size, x, dst(e)), _read(rep_size, x, src(e)))
         end
     end
     return v
 end
-function incident_log!(M::GraphManifold{<:AbstractSimpleWeightedGraph, <:Manifold, VertexManifold}, v, x)
+function incident_log!(
+    M::GraphManifold{<:AbstractSimpleWeightedGraph,<:Manifold,VertexManifold},
+    v,
+    x,
+)
     rep_size = representation_size(M.manifold)
     rsC = rep_size_to_colons(rep_size)
     for e in edges(M.graph)
-        v[rsC...,src(e)] += get_weight(M.graph, src(e), dst(e))*log(M.manifold, _read(rep_size, x, src(e)), _read(rep_size, x, dst(e)))
+        v[rsC..., src(e)] += (
+            get_weight(M.graph, src(e), dst(e)) *
+                log(M.manifold, _read(rep_size, x, src(e)), _read(rep_size, x, dst(e)))
+        )
         if !is_directed(M.graph)
-            v[rsC...,dst(e)] += get_weight(M.graph, dst(e), src(e))*log(M.manifold, _read(rep_size, x, dst(e)), _read(rep_size, x, src(e)))
+            v[rsC..., dst(e)] += (
+                get_weight(M.graph, dst(e), src(e)) *
+                    log(M.manifold, _read(rep_size, x, dst(e)), _read(rep_size, x, src(e)))
+            )
         end
     end
     return v
@@ -157,8 +194,8 @@ a graph $G=(V,E)$, i.e.
 d_{\mathcal N} = \lvert V \rVert d_{\mathcal M}.
 ````
 """
-function manifold_dimension(M::GraphManifold{<:AbstractGraph, <:Manifold, VertexManifold})
-    return manifold_dimension(M.manifold)*nv(M.graph)
+function manifold_dimension(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold})
+    return manifold_dimension(M.manifold) * nv(M.graph)
 end
 @doc doc"""
     manifold_dimension(N::GraphManifold{G,M,EdgeManifold})
@@ -169,8 +206,8 @@ a graph $G=(V,E)$, i.e.
 d_{\mathcal N} = \lvert E \rVert d_{\mathcal M}.
 ````
 """
-function manifold_dimension(M::GraphManifold{<:AbstractGraph, <:Manifold, EdgeManifold})
-    return manifold_dimension(M.manifold)*ne(M.graph)
+function manifold_dimension(M::GraphManifold{<:AbstractGraph,<:Manifold,EdgeManifold})
+    return manifold_dimension(M.manifold) * ne(M.graph)
 end
 
 @doc doc"""
@@ -179,7 +216,7 @@ end
 returns the representation size of a point on the [`GraphManifold`](@ref) on the vertices of $G=(V,E),
 which is the representation size of `M` with $\lvert V \rvert$ added.
 """
-function representation_size(M::GraphManifold{<:AbstractGraph, <:Manifold, VertexManifold})
+function representation_size(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold})
     return (representation_size(M.manifold)..., nv(M.graph))
 end
 @doc doc"""
@@ -188,13 +225,13 @@ end
 returns the representation size of a point on the [`GraphManifold`](@ref) on the vertices of $G=(V,E),
 which is the representation size of `M` with $\lvert E \rvert$ added.
 """
-function representation_size(M::GraphManifold{<:AbstractGraph, <:Manifold, EdgeManifold})
+function representation_size(M::GraphManifold{<:AbstractGraph,<:Manifold,EdgeManifold})
     return (representation_size(M.manifold)..., ne(M.graph))
 end
 
-function zero_tangent_vector(M::GraphManifold{<:AbstractGraph, <:Manifold, VertexManifold}, x)
-    return zero_tangent_vector(PowerManifold(M.manifold,nv(M.graph)), x)
+function zero_tangent_vector(M::GraphManifold{<:AbstractGraph,<:Manifold,VertexManifold}, x)
+    return zero_tangent_vector(PowerManifold(M.manifold, nv(M.graph)), x)
 end
 function zero_tangent_vector(M::GraphManifold{<:AbstractGraph,<:Manifold,EdgeManifold}, x)
-    return zero_tangent_vector(PowerManifold(M.manifold,ne(M.graph)), x)
+    return zero_tangent_vector(PowerManifold(M.manifold, ne(M.graph)), x)
 end

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra: svd, qr, diag, Diagonal, det
-import LinearAlgebra: norm
 @doc doc"""
     Grassmann{n,k,F} <: Manifold
 

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -54,6 +54,7 @@ Generate the Grassmann manifold $\operatorname{Gr}(n,k)$, where the real-valued
 case $\mathbb F = \mathbb R$ is the default.
 """
 struct Grassmann{n,k,F} <: Manifold end
+
 Grassmann(n::Int, k::Int, F::AbstractNumbers = ℝ) = Grassmann{n,k,F}()
 
 @doc doc"""
@@ -174,6 +175,7 @@ yielding the result as
 ````
 """
 exp(::Grassmann, ::Any...)
+
 function exp!(M::Grassmann, y, x, v)
     norm(M, x, v) ≈ 0 && return copyto!(y, x)
     d = svd(v)
@@ -212,6 +214,7 @@ Compute the inverse retraction for the [`PolarRetraction`](@ref), on the
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
 inverse_retract(M::Grassmann, ::Any, ::Any, ::PolarInverseRetraction)
+
 function inverse_retract!(::Grassmann, v, x, y, ::PolarInverseRetraction)
     return copyto!(v, y / (x' * y) - x)
 end
@@ -227,6 +230,7 @@ Compute the inverse retraction valid of the [`QRRetraction`](@ref)
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
 inverse_retract(::Grassmann, ::Any, ::Any, ::QRInverseRetraction)
+
 inverse_retract!(::Grassmann, v, x, y, ::QRInverseRetraction) = copyto!(v, y / (x' * y) - x)
 
 function isapprox(M::Grassmann, x, v, w; kwargs...)
@@ -254,6 +258,7 @@ USV = (y^\mathrm{H}x)^{-1} ( y^\mathrm{H} - y^\mathrm{H}xx^\mathrm{H} ).
 In this formula the $\operatorname{atan}$ is meant elementwise.
 """
 log(::Grassmann, ::Any...)
+
 function log!(M::Grassmann, v, x, y)
     z = y' * x
     At = y' - z * x'
@@ -288,6 +293,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Grassmann{n,k,ℝ} where {n,k}, ::Any...)
+
 function mean!(
     M::Grassmann{n,k,ℝ},
     y,
@@ -311,6 +317,7 @@ which is computed by
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
 project_tangent(::Grassmann, ::Any...)
+
 project_tangent!(M::Grassmann, v, x, w) = copyto!(v, w - x * x' * w)
 
 @doc doc"""
@@ -331,14 +338,7 @@ Compute the SVD-based retraction [`PolarRetraction`](@ref) on the
 ````
 
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
-"""
-retract(::Grassmann, ::Any, ::Any, ::PolarRetraction)
-function retract!(::Grassmann, y, x, v, ::PolarRetraction)
-    s = svd(x + v)
-    return mul!(y, s.U, s.V')
-end
 
-@doc doc"""
     retract(M::Grassmann, x, v, ::QRRetraction )
 
 Compute the QR-based retraction [`QRRetraction`](@ref) on the
@@ -351,7 +351,12 @@ where D is a $m\times n$ matrix with
 D = \operatorname{diag}( \operatorname{sgn}(R_{ii}+0,5)_{i=1}^n ).
 ````
 """
-retract(M::Grassmann, ::Any, ::Any, ::QRRetraction)
+retract(::Grassmann, ::Any...)
+
+function retract!(::Grassmann, y, x, v, ::PolarRetraction)
+    s = svd(x + v)
+    return mul!(y, s.U, s.Vt)
+end
 function retract!(::Grassmann{N,K}, y, x, v, ::QRRetraction) where {N,K}
     qrfac = qr(x + v)
     d = diag(qrfac.R)
@@ -368,4 +373,5 @@ Return the zero tangent vector from the tangent space at `x` on the [`Grassmann`
 which is given by a zero matrix the same size as `x`.
 """
 zero_tangent_vector(::Grassmann, ::Any...)
+
 zero_tangent_vector!(::Grassmann, v, x) = fill!(v, 0)

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -56,7 +56,7 @@ Generate the Grassmann manifold $\operatorname{Gr}(n,k)$, where the real-valued
 case $\mathbb F = \mathbb R$ is the default.
 """
 struct Grassmann{n,k,F} <: Manifold end
-Grassmann(n::Int, k::Int, F::AbstractNumbers=ℝ) = Grassmann{n,k,F}()
+Grassmann(n::Int, k::Int, F::AbstractNumbers = ℝ) = Grassmann{n,k,F}()
 
 @doc doc"""
     check_manifold_point(M::Grassmann{n,k,F}, x)
@@ -64,23 +64,31 @@ Grassmann(n::Int, k::Int, F::AbstractNumbers=ℝ) = Grassmann{n,k,F}()
 Check whether `x` is representing a point on the [`Grassmann`](@ref) `M`, i.e. its
 a `n`-by-`k` matrix of unitary column vectors and of correct `eltype` with respect to `F`.
 """
-function check_manifold_point(M::Grassmann{n,k,F},x; kwargs...) where {n,k,F}
-    if (F===ℝ) && !(eltype(x) <: Real)
-        return DomainError(eltype(x),
-            "The matrix $(x) is not a real-valued matrix, so it does noe lie on the Grassmann manifold of dimension ($(n),$(k)).")
+function check_manifold_point(M::Grassmann{n,k,F}, x; kwargs...) where {n,k,F}
+    if (F === ℝ) && !(eltype(x) <: Real)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) is not a real-valued matrix, so it does noe lie on the Grassmann manifold of dimension ($(n),$(k)).",
+        )
     end
-    if (F===ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
-        return DomainError(eltype(x),
-            "The matrix $(x) is neiter real- nor complex-valued matrix, so it does noe lie on the complex Grassmann manifold of dimension ($(n),$(k)).")
+    if (F === ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) is neiter real- nor complex-valued matrix, so it does noe lie on the complex Grassmann manifold of dimension ($(n),$(k)).",
+        )
     end
     if size(x) != representation_size(M)
-        return DomainError(size(x),
-            "The matrix $(x) is does not lie on the Grassmann manifold of dimension ($(n),$(k)), since its dimensions are wrong.")
+        return DomainError(
+            size(x),
+            "The matrix $(x) is does not lie on the Grassmann manifold of dimension ($(n),$(k)), since its dimensions are wrong.",
+        )
     end
-    c = x'*x
+    c = x' * x
     if !isapprox(c, one(c); kwargs...)
-        return DomainError(norm(c-one(c)),
-            "The point $(x) does not lie on the Grassmann manifold of dimension ($(n),$(k)), because x'x is not the unit matrix.")
+        return DomainError(
+            norm(c - one(c)),
+            "The point $(x) does not lie on the Grassmann manifold of dimension ($(n),$(k)), because x'x is not the unit matrix.",
+        )
     end
 end
 
@@ -97,26 +105,34 @@ Check whether `v` is a tangent vector in the tangent space of `x` on the [`Grass
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transpose or Hermitian and $0_k$
 denotes the $k\times k$ zero natrix.
 """
-function check_tangent_vector(G::Grassmann{n,k,F},x,v; kwargs...) where {n,k,F}
-    t = check_manifold_point(G,x)
+function check_tangent_vector(G::Grassmann{n,k,F}, x, v; kwargs...) where {n,k,F}
+    t = check_manifold_point(G, x)
     if (t !== nothing)
         return t
     end
-    if (F===ℝ) && !(eltype(v) <: Real)
-        return DomainError(eltype(v),
-            "The matrix $(v) is not a real-valued matrix, so it can not be a tangent vector to the Grassmann manifold of dimension ($(n),$(k)).")
+    if (F === ℝ) && !(eltype(v) <: Real)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is not a real-valued matrix, so it can not be a tangent vector to the Grassmann manifold of dimension ($(n),$(k)).",
+        )
     end
-    if (F===ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
-        return DomainError(eltype(v),
-            "The matrix $(v) is neiter real- nor complex-valued matrix, so it can not bea tangent vector to the complex Grassmann manifold of dimension ($(n),$(k)).")
+    if (F === ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is neiter real- nor complex-valued matrix, so it can not bea tangent vector to the complex Grassmann manifold of dimension ($(n),$(k)).",
+        )
     end
     if size(v) != representation_size(G)
-        return DomainError(size(v),
-            "The matrix $(v) is does not lie in the tangent space of $(x) on the Grassmann manifold of dimension ($(n),$(k)), since its dimensions are wrong.")
+        return DomainError(
+            size(v),
+            "The matrix $(v) is does not lie in the tangent space of $(x) on the Grassmann manifold of dimension ($(n),$(k)), since its dimensions are wrong.",
+        )
     end
-    if !isapprox(x'*v + v'*x, zeros(k,k); kwargs...)
-        return DomainError(norm(x'*v + v'*x),
-            "The matrix $(v) is does not lie in the tangent space of $(x) on the Grassmann manifold of dimension ($(n),$(k)), since x'v + v'x is not the zero matrix.")
+    if !isapprox(x' * v + v' * x, zeros(k, k); kwargs...)
+        return DomainError(
+            norm(x' * v + v' * x),
+            "The matrix $(v) is does not lie in the tangent space of $(x) on the Grassmann manifold of dimension ($(n),$(k)), since x'v + v'x is not the zero matrix.",
+        )
     end
 end
 
@@ -137,11 +153,11 @@ $b_{i}=\begin{cases} 0 & \text{if} \; S_i \geq 1\\ \operatorname{acos}(S_i) & \,
 """
 function distance(M::Grassmann, x, y)
     if x ≈ y
-        return 0.
+        return 0.0
     else
-        a = svd(x'*y).S
-        a[a .> 1] .= 1
-        return sqrt(sum( (acos.(a)).^2 ))
+        a = svd(x' * y).S
+        a[a.>1] .= 1
+        return sqrt(sum((acos.(a)) .^ 2))
     end
 end
 
@@ -164,19 +180,19 @@ yielding the result as
 \exp_x v = Q.
 ````
 """
-exp(::Grassmann,::Any...)
-function exp!(M::Grassmann,y, x, v)
-    if norm(M,x,v) ≈ 0
+exp(::Grassmann, ::Any...)
+function exp!(M::Grassmann, y, x, v)
+    if norm(M, x, v) ≈ 0
         return (y .= x)
     end
     d = svd(v)
-    z =  x * d.V * Diagonal(cos.(d.S)) * d.Vt + d.U * Diagonal(sin.(d.S)) * d.Vt
+    z = x * d.V * Diagonal(cos.(d.S)) * d.Vt + d.U * Diagonal(sin.(d.S)) * d.Vt
     # reorthonormalize
-    copyto!(y, Array(qr(z).Q) )
+    copyto!(y, Array(qr(z).Q))
     return y
 end
 
-injectivity_radius(::Grassmann) = π/2
+injectivity_radius(::Grassmann) = π / 2
 
 @doc doc"""
     inner(M::Grassmann, x, v, w)
@@ -191,7 +207,7 @@ g_x(v,w) = \operatorname{trace}(v^{\mathrm{H}}w),
 
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
-inner(::Grassmann, x, v, w) = dot(v,w)
+inner(::Grassmann, x, v, w) = dot(v, w)
 
 @doc doc"""
     inverse_retract(M::Grassmann, x, y, ::PolarInverseRetraction)
@@ -206,7 +222,7 @@ Compute the inverse retraction for the [`PolarRetraction`](@ref), on the
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
 inverse_retract(M::Grassmann, ::Any, ::Any, ::PolarInverseRetraction)
-inverse_retract!(::Grassmann, v, x, y, ::PolarInverseRetraction) = ( v .= y/(x'*y) - x)
+inverse_retract!(::Grassmann, v, x, y, ::PolarInverseRetraction) = (v .= y / (x' * y) - x)
 
 @doc doc"""
     inverse_retract(M, x, y, ::QRInverseRetraction)
@@ -219,13 +235,11 @@ Compute the inverse retraction valid of the [`QRRetraction`](@ref)
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
 inverse_retract(::Grassmann, ::Any, ::Any, ::QRInverseRetraction)
-inverse_retract!(::Grassmann, v, x, y, ::QRInverseRetraction) = ( v .= y/(x'*y) - x)
+inverse_retract!(::Grassmann, v, x, y, ::QRInverseRetraction) = (v .= y / (x' * y) - x)
 
-isapprox(M::Grassmann, x, v, w; kwargs...) = isapprox(
-    sqrt(inner(M,x,zero_tangent_vector(M,x),v-w)),0;
-    kwargs...
-)
-isapprox(M::Grassmann, x, y; kwargs...) = isapprox(distance(M,x,y),0.; kwargs...)
+isapprox(M::Grassmann, x, v, w; kwargs...) =
+    isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+isapprox(M::Grassmann, x, y; kwargs...) = isapprox(distance(M, x, y), 0.0; kwargs...)
 
 @doc doc"""
     log(M::Grassmann, x, y)
@@ -246,11 +260,11 @@ USV = (y^\mathrm{H}x)^{-1} ( y^\mathrm{H} - y^\mathrm{H}xx^\mathrm{H} ).
 ````
 In this formula the $\operatorname{atan}$ is meant elementwise.
 """
-log(::Grassmann,::Any...)
+log(::Grassmann, ::Any...)
 function log!(M::Grassmann, v, x, y)
-    z = y'*x
-    At = y' - z*x'
-    Bt = z\At
+    z = y' * x
+    At = y' - z * x'
+    Bt = z \ At
     d = svd(Bt')
     v .= d.U * Diagonal(atan.(d.S)) * d.Vt
     return v
@@ -267,7 +281,7 @@ Return the dimension of the [`Grassmann(n,k,𝔽)`](@ref) manifold `M`, i.e.
 
 where $\dim_ℝ 𝔽$ is the [`real_dimension`](@ref) of `𝔽`.
 """
-manifold_dimension(M::Grassmann{n,k,𝔽}) where {n,k,𝔽} = k*(n - k)*real_dimension(𝔽)
+manifold_dimension(M::Grassmann{n,k,𝔽}) where {n,k,𝔽} = k * (n - k) * real_dimension(𝔽)
 
 """
     mean(
@@ -283,7 +297,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 """
 mean(::Grassmann{n,k,ℝ} where {n,k}, ::Any...)
 mean!(M::Grassmann{n,k,ℝ}, y, x::AbstractVector, w::AbstractVector; kwargs...) where {n,k} =
-    mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π/4); kwargs...)
+    mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 4); kwargs...)
 
 @doc doc"""
     project_tangent(M::Grassmann, x, w)
@@ -297,8 +311,8 @@ which is computed by
 
 where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian.
 """
-project_tangent(::Grassmann,::Any...)
-project_tangent!(M::Grassmann,v, x, w) = ( v .= w - x*x'*w )
+project_tangent(::Grassmann, ::Any...)
+project_tangent!(M::Grassmann, v, x, w) = (v .= w - x * x' * w)
 
 @doc doc"""
     representation_size(M::Grassmann{n,k,F})
@@ -306,7 +320,7 @@ project_tangent!(M::Grassmann,v, x, w) = ( v .= w - x*x'*w )
 Return the represenation size or matrix dimension of a point on the [`Grassmann`](@ref)
 `M`, i.e. $(n,k)$ for both the real-valued and the complex value case.
 """
-@generated representation_size(::Grassmann{n, k}) where {n,k} = (n,k)
+@generated representation_size(::Grassmann{n,k}) where {n,k} = (n, k)
 
 @doc doc"""
     retract(M::Grassmann, x, v, ::PolarRetraction)
@@ -321,9 +335,9 @@ where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian
 """
 retract(::Grassmann, ::Any, ::Any, ::PolarRetraction)
 function retract!(::Grassmann, y, x, v, ::PolarRetraction)
-    s = svd(x+v)
+    s = svd(x + v)
     mul!(y, s.U, s.V')
-   return y
+    return y
 end
 
 @doc doc"""
@@ -341,11 +355,11 @@ D = \operatorname{diag}( \operatorname{sgn}(R_{ii}+0,5)_{i=1}^n ).
 """
 retract(M::Grassmann, ::Any, ::Any, ::QRRetraction)
 function retract!(::Grassmann{N,K}, y, x, v, ::QRRetraction) where {N,K}
-    qrfac = qr(x+v)
+    qrfac = qr(x + v)
     d = diag(qrfac.R)
-    D = Diagonal( sign.( sign.(d .+ 0.5)) )
-    y .= zeros(N,K)
-    y[1:K,1:K] .= D
+    D = Diagonal(sign.(sign.(d .+ 0.5)))
+    y .= zeros(N, K)
+    y[1:K, 1:K] .= D
     y .= Array(qrfac.Q) * D
     return y
 end
@@ -357,4 +371,4 @@ Return the zero tangent vector from the tangent space at `x` on the [`Grassmann`
 which is given by a zero matrix the same size as `x`.
 """
 zero_tangent_vector(::Grassmann, ::Any...)
-zero_tangent_vector!(::Grassmann,v,x) = fill!(v,0)
+zero_tangent_vector!(::Grassmann, v, x) = fill!(v, 0)

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -237,8 +237,9 @@ where $\cdot^{\mathrm{H}}$ denotes the complex conjugate transposed or Hermitian
 inverse_retract(::Grassmann, ::Any, ::Any, ::QRInverseRetraction)
 inverse_retract!(::Grassmann, v, x, y, ::QRInverseRetraction) = (v .= y / (x' * y) - x)
 
-isapprox(M::Grassmann, x, v, w; kwargs...) =
-    isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+function isapprox(M::Grassmann, x, v, w; kwargs...)
+    return isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+end
 isapprox(M::Grassmann, x, y; kwargs...) = isapprox(distance(M, x, y), 0.0; kwargs...)
 
 @doc doc"""
@@ -296,8 +297,15 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Grassmann{n,k,ℝ} where {n,k}, ::Any...)
-mean!(M::Grassmann{n,k,ℝ}, y, x::AbstractVector, w::AbstractVector; kwargs...) where {n,k} =
-    mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 4); kwargs...)
+function mean!(
+    M::Grassmann{n,k,ℝ},
+    y,
+    x::AbstractVector,
+    w::AbstractVector;
+    kwargs...,
+) where {n,k}
+    return mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 4); kwargs...)
+end
 
 @doc doc"""
     project_tangent(M::Grassmann, x, w)

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -238,7 +238,7 @@ project_tangent!(::Hyperbolic, w, x, v) = (w .= v .+ minkowski_dot(x, v) .* x)
 Return the representation size on the [`Hyperbolic`](@ref), i.e. for the `n`-diomensional
 hyperbolic manifold the dimention of the embedding, i.e. `n+1`.
 """
-representation_size(::Hyperbolic{N}) where {N} = (N + 1,)
+@generated representation_size(::Hyperbolic{N}) where {N} = (N + 1,)
 
 sharp!(M::Hyperbolic, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -28,6 +28,7 @@ a Riemannian metric on the tangent bundle $T\mathbb H^n$.
 Generate the $\mathbb H^{n}\subset \mathbb R^{n+1}$
 """
 struct Hyperbolic{N} <: Manifold end
+
 Hyperbolic(n::Int) = Hyperbolic{n}()
 
 @doc doc"""
@@ -123,6 +124,7 @@ from `x` towards `v`, which is optionally scaled by `t`. The formula reads
 where $\langle\cdot,\cdot\rangle_{\mathrm{M}}$ denotes the [`minkowski_dot`](@ref).
 """
 exp(::Hyperbolic, ::Any...)
+
 function exp!(M::Hyperbolic, y, x, v)
     vn = sqrt(max(minkowski_dot(v, v), 0.0))
     vn < eps(eltype(x)) && return copyto!(y, x)
@@ -165,6 +167,7 @@ The formula reads for $x\neq y$
 and is zero otherwise.
 """
 log(::Hyperbolic, ::Any...)
+
 function log!(M::Hyperbolic, v, x, y)
     scp = minkowski_dot(x, y)
     w = y + scp * x
@@ -207,6 +210,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` on the
 [`Hyperbolic`](@ref) space using [`CyclicProximalPointEstimation`](@ref).
 """
 mean(::Hyperbolic, ::Any...)
+
 function mean!(M::Hyperbolic, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return mean!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
 end
@@ -225,6 +229,7 @@ where $\langle \cdot, \cdot \rangle_{\mathrm{M}}$ denotes the Minkowski inner
 product in the embedding, see [`minkowski_dot`](@ref).
 """
 project_tangent(::Hyperbolic, ::Any...)
+
 project_tangent!(::Hyperbolic, w, x, v) = (w .= v .+ minkowski_dot(x, v) .* x)
 
 @doc doc"""
@@ -250,6 +255,7 @@ P_{y\gets x}(v) = v - \frac{\langle \log_xy,v\rangle_x}{d^2_{\mathbb H^n}(x,y)}
 ````
 """
 vector_transport_to(::Hyperbolic, ::Any, ::Any, ::Any, ::ParallelTransport)
+
 function vector_transport_to!(M::Hyperbolic, vto, x, v, y, ::ParallelTransport)
     w = log(M, x, y)
     wn = norm(M, x, w)
@@ -263,4 +269,5 @@ end
 Return the zero vector from the tangent space at `x` of the [`Hyperbolic`](@ref) `M`.
 """
 zero_tangent_vector(::HybridArray, ::Any...)
+
 zero_tangent_vector!(M::Hyperbolic, v, x) = fill!(v, 0)

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -56,10 +56,16 @@ Check whether `x` is a valid point on the [`Hyperbolic`](@ref) `M`, i.e. is a ve
 """
 function check_manifold_point(M::Hyperbolic, x; kwargs...)
     if size(x) != representation_size(M)
-        return DomainError(size(x),"The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).")
+        return DomainError(
+            size(x),
+            "The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).",
+        )
     end
-    if !isapprox(minkowski_dot(x,x), -1.; kwargs...)
-        return DomainError(minkowski_dot(x,x), "The point $(x) does not lie on $(M) since its Minkowski inner product is not -1.")
+    if !isapprox(minkowski_dot(x, x), -1.0; kwargs...)
+        return DomainError(
+            minkowski_dot(x, x),
+            "The point $(x) does not lie on $(M) since its Minkowski inner product is not -1.",
+        )
     end
     return nothing
 end
@@ -73,15 +79,18 @@ and orthogonal to `x` with respect to [`minkowski_dot`](@ref).
 The tolerance for the last test can be set using the `kwargs...`.
 """
 function check_tangent_vector(M::Hyperbolic, x, v; kwargs...)
-    perr = check_manifold_point(M,x)
+    perr = check_manifold_point(M, x)
     perr === nothing || return perr
     if size(v) != representation_size(M)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $M since its size does not match $(representation_size(M)).")
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $M since its size does not match $(representation_size(M)).",
+        )
     end
-    if !isapprox( minkowski_dot(x,v), 0.; kwargs...)
-        return DomainError(abs( minkowski_dot(x,v)),
-            "The vector $(v) is not a tangent vector to $(x) on $(M), since it is not orthogonal (with respect to the Minkowski inner product) in the embedding."
+    if !isapprox(minkowski_dot(x, v), 0.0; kwargs...)
+        return DomainError(
+            abs(minkowski_dot(x, v)),
+            "The vector $(v) is not a tangent vector to $(x) on $(M), since it is not orthogonal (with respect to the Minkowski inner product) in the embedding.",
         )
     end
     return nothing
@@ -98,7 +107,7 @@ d_{\mathbb H^n}(x,y) = \operatorname{acosh}( - \langle x, y \rangle_{\mathrm{M}}
 
 where $\langle\cdot,\cdot\rangle_{\mathrm{M}}$ denotes the [`minkowski_dot`](@ref).
 """
-distance(M::Hyperbolic, x, y) = acosh(max(-minkowski_dot(x, y), 1.))
+distance(M::Hyperbolic, x, y) = acosh(max(-minkowski_dot(x, y), 1.0))
 
 @doc doc"""
     exp(M::Hyperbolic, x, v)
@@ -115,16 +124,21 @@ where $\langle\cdot,\cdot\rangle_{\mathrm{M}}$ denotes the [`minkowski_dot`](@re
 """
 exp(::Hyperbolic, ::Any...)
 function exp!(M::Hyperbolic, y, x, v)
-    vn = sqrt(max(minkowski_dot(v, v),0.))
+    vn = sqrt(max(minkowski_dot(v, v), 0.0))
     if vn < eps(eltype(x))
         y .= x
         return y
     end
-    y .= cosh(vn)*x + sinh(vn)/vn*v
+    y .= cosh(vn) * x + sinh(vn) / vn * v
     return y
 end
 
-function flat!(M::Hyperbolic, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
+function flat!(
+    M::Hyperbolic,
+    v::FVector{CotangentSpaceType},
+    x,
+    w::FVector{TangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
@@ -146,7 +160,7 @@ inner product on $\mathbb R^{n+1}$.
 """
 @inline inner(M::Hyperbolic, x, w, v) = minkowski_dot(w, v)
 
-is_default_metric(::Hyperbolic,::MinkowskiMetric) = Val(true)
+is_default_metric(::Hyperbolic, ::MinkowskiMetric) = Val(true)
 
 @doc doc"""
     log(M::Hyperbolic, x, y)
@@ -162,16 +176,16 @@ The formula reads for $x\neq y$
 ```
 and is zero otherwise.
 """
-log(::Hyperbolic,::Any...)
+log(::Hyperbolic, ::Any...)
 function log!(M::Hyperbolic, v, x, y)
     scp = minkowski_dot(x, y)
-    w = y + scp*x
-    wn = sqrt(max( scp.^2-1, 0.))
+    w = y + scp * x
+    wn = sqrt(max(scp .^ 2 - 1, 0.0))
     if wn < eps(eltype(x))
-        zero_tangent_vector!(M,v,x)
+        zero_tangent_vector!(M, v, x)
         return v
     end
-    v .= acosh(max(1.,-scp))/wn .* w
+    v .= acosh(max(1.0, -scp)) / wn .* w
     return v
 end
 
@@ -184,7 +198,8 @@ Compute the Minkowski inner product of two Vectors `a` and `b` of same length
 \langle a,b\rangle_{\mathrm{M}} = -a_{n+1}b_{n+1} + \displaystyle\sum_{k=1}^n a_kb_k.
 ````
 """
-minkowski_dot(a::AbstractVector,b::AbstractVector) = -a[end]*b[end] + sum( a[1:end-1].*b[1:end-1] )
+minkowski_dot(a::AbstractVector, b::AbstractVector) =
+    -a[end] * b[end] + sum(a[1:end-1] .* b[1:end-1])
 
 @doc doc"""
     manifold_dimension(H::Hyperbolic)
@@ -207,7 +222,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` on the
 """
 mean(::Hyperbolic, ::Any...)
 mean!(M::Hyperbolic, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(M, y, x, w,  CyclicProximalPointEstimation(); kwargs...)
+    mean!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
 
 @doc doc"""
     project_tangent(M::Hyperbolic, x, v)
@@ -222,7 +237,7 @@ w = v + \langle x,v\rangle_{\mathrm{M}} x,
 where $\langle \cdot, \cdot \rangle_{\mathrm{M}}$ denotes the Minkowski inner
 product in the embedding, see [`minkowski_dot`](@ref).
 """
-project_tangent(::Hyperbolic,::Any...)
+project_tangent(::Hyperbolic, ::Any...)
 project_tangent!(::Hyperbolic, w, x, v) = (w .= v .+ minkowski_dot(x, v) .* x)
 
 @doc doc"""
@@ -231,9 +246,14 @@ project_tangent!(::Hyperbolic, w, x, v) = (w .= v .+ minkowski_dot(x, v) .* x)
 Return the representation size on the [`Hyperbolic`](@ref), i.e. for the `n`-diomensional
 hyperbolic manifold the dimention of the embedding, i.e. `n+1`.
 """
-representation_size(::Hyperbolic{N}) where {N} = (N+1,)
+representation_size(::Hyperbolic{N}) where {N} = (N + 1,)
 
-function sharp!(M::Hyperbolic, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
+function sharp!(
+    M::Hyperbolic,
+    v::FVector{TangentSpaceType},
+    x,
+    w::FVector{CotangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
@@ -252,13 +272,13 @@ P_{y\gets x}(v) = v - \frac{\langle \log_xy,v\rangle_x}{d^2_{\mathbb H^n}(x,y)}
 """
 vector_transport_to(::Hyperbolic, ::Any, ::Any, ::Any, ::ParallelTransport)
 function vector_transport_to!(M::Hyperbolic, vto, x, v, y, ::ParallelTransport)
-    w = log(M,x,y)
-    wn = norm(M,x,w)
-    if (wn < eps(eltype(x+y)))
-        copyto!(vto,v)
+    w = log(M, x, y)
+    wn = norm(M, x, w)
+    if (wn < eps(eltype(x + y)))
+        copyto!(vto, v)
         return vto
     end
-    vto .= v - (inner(M,x,w,v)*(w + log(M,y,x))/wn^2 )
+    vto .= v - (inner(M, x, w, v) * (w + log(M, y, x)) / wn^2)
     return vto
 end
 
@@ -267,7 +287,7 @@ end
 
 Return the zero vector from the tangent space at `x` of the [`Hyperbolic`](@ref) `M`.
 """
-zero_tangent_vector(::HybridArray,::Any...)
+zero_tangent_vector(::HybridArray, ::Any...)
 function zero_tangent_vector!(M::Hyperbolic, v, x)
     fill!(v, 0)
     return v

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -129,14 +129,7 @@ function exp!(M::Hyperbolic, y, x, v)
     return copyto!(y, cosh(vn) * x + sinh(vn) / vn * v)
 end
 
-function flat!(
-    M::Hyperbolic,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
-    return copyto!(v, w)
-end
+flat!(M::Hyperbolic, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 @doc doc"""
     injectivity_radius(M::Hyperbolic[, x])
@@ -242,14 +235,7 @@ hyperbolic manifold the dimention of the embedding, i.e. `n+1`.
 """
 representation_size(::Hyperbolic{N}) where {N} = (N + 1,)
 
-function sharp!(
-    M::Hyperbolic,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
-    return copyto!(v, w)
-end
+sharp!(M::Hyperbolic, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 @doc doc"""
     vector_transport_to(M::Hyperbolic, x, v, y, ::ParallelTransport)

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -135,8 +135,7 @@ function flat!(
     x,
     w::FVector{TangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 @doc doc"""
@@ -249,8 +248,7 @@ function sharp!(
     x,
     w::FVector{CotangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 @doc doc"""

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -198,8 +198,9 @@ Compute the Minkowski inner product of two Vectors `a` and `b` of same length
 \langle a,b\rangle_{\mathrm{M}} = -a_{n+1}b_{n+1} + \displaystyle\sum_{k=1}^n a_kb_k.
 ````
 """
-minkowski_dot(a::AbstractVector, b::AbstractVector) =
-    -a[end] * b[end] + sum(a[1:end-1] .* b[1:end-1])
+function minkowski_dot(a::AbstractVector, b::AbstractVector)
+    return -a[end] * b[end] + sum(a[1:end-1] .* b[1:end-1])
+end
 
 @doc doc"""
     manifold_dimension(H::Hyperbolic)
@@ -221,8 +222,9 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` on the
 [`Hyperbolic`](@ref) space using [`CyclicProximalPointEstimation`](@ref).
 """
 mean(::Hyperbolic, ::Any...)
-mean!(M::Hyperbolic, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
+function mean!(M::Hyperbolic, y, x::AbstractVector, w::AbstractVector; kwargs...)
+    return mean!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
+end
 
 @doc doc"""
     project_tangent(M::Hyperbolic, x, v)

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -46,10 +46,12 @@ inner product $g(v, v) > 0$ whenever $v$ is not the zero vector.
 """
 abstract type RiemannianMetric <: Metric end
 
-check_manifold_point(M::MetricManifold, x; kwargs...) =
-    check_manifold_point(M.manifold, x; kwargs...)
-check_tangent_vector(M::MetricManifold, x, v; kwargs...) =
-    check_tangent_vector(M.manifold, x, v; kwargs...)
+function check_manifold_point(M::MetricManifold, x; kwargs...)
+    return check_manifold_point(M.manifold, x; kwargs...)
+end
+function check_tangent_vector(M::MetricManifold, x, v; kwargs...)
+    return check_tangent_vector(M.manifold, x, v; kwargs...)
+end
 
 @doc doc"""
     christoffel_symbols_first(M::MetricManifold, x; backend=:default)
@@ -146,10 +148,18 @@ coordinate chart that covers the entire manifold. This excludes coordinates
 in an embedded space.
 """
 exp(::MetricManifold, ::Any)
-exp(M::MMT, x, v, T::AbstractVector{T} where {T}) where {MMT<:MetricManifold} =
-    exp(M, is_default_metric(M), x, v, T)
-exp(M::MMT, ::Val{true}, x, v, T::AbstractVector{T} where {T}) where {MMT<:MetricManifold} =
-    exp(base_manifold(M), x, v, T)
+function exp(M::MMT, x, v, T::AbstractVector{T} where {T}) where {MMT<:MetricManifold}
+    return exp(M, is_default_metric(M), x, v, T)
+end
+function exp(
+    M::MMT,
+    ::Val{true},
+    x,
+    v,
+    T::AbstractVector{T} where {T},
+) where {MMT<:MetricManifold}
+    return exp(base_manifold(M), x, v, T)
+end
 function exp(
     M::MMT,
     ::Val{false},
@@ -163,8 +173,9 @@ function exp(
 end
 
 exp!(M::MMT, y, x, v) where {MMT<:MetricManifold} = exp!(M, is_default_metric(M), y, x, v)
-exp!(M::MMT, ::Val{true}, y, x, v) where {MMT<:MetricManifold} =
-    exp!(base_manifold(M), y, x, v)
+function exp!(M::MMT, ::Val{true}, y, x, v) where {MMT<:MetricManifold}
+    return exp!(base_manifold(M), y, x, v)
+end
 function exp!(M::MMT, ::Val{false}, y, x, v) where {MMT<:MetricManifold}
     tspan = (0.0, 1.0)
     sol = solve_exp_ode(M, x, v, tspan; dense = false, saveat = [1.0])
@@ -204,17 +215,22 @@ Compute the Gaussian curvature of the manifold `M` at the point `x`.
 """
 gaussian_curvature(M::MetricManifold, x; kwargs...) = ricci_curvature(M, x; kwargs...) / 2
 
-get_basis(M::MMT, x, B::ArbitraryOrthonormalBasis) where {MMT<:MetricManifold} =
-    invoke(get_basis, Tuple{MMT,Any,AbstractBasis}, M, x, B)
-get_basis(M::MMT, x, B::AbstractBasis) where {MMT<:MetricManifold} =
-    get_basis(M, is_default_metric(M), x, B)
-get_basis(M::MMT, ::Val{true}, x, B::AbstractBasis) where {MMT<:MetricManifold} =
-    get_basis(base_manifold(M), x, B)
-get_basis(M::MMT, ::Val{false}, x, B::AbstractBasis) where {MMT<:MetricManifold} =
+function get_basis(M::MMT, x, B::ArbitraryOrthonormalBasis) where {MMT<:MetricManifold}
+    return invoke(get_basis, Tuple{MMT,Any,AbstractBasis}, M, x, B)
+end
+function get_basis(M::MMT, x, B::AbstractBasis) where {MMT<:MetricManifold}
+    return get_basis(M, is_default_metric(M), x, B)
+end
+function get_basis(M::MMT, ::Val{true}, x, B::AbstractBasis) where {MMT<:MetricManifold}
+    return get_basis(base_manifold(M), x, B)
+end
+function get_basis(M::MMT, ::Val{false}, x, B::AbstractBasis) where {MMT<:MetricManifold}
     error("tangent_orthogonal_basis not implemented on $(typeof(M)) for point $(typeof(x)) and basis type $(typeof(B)).")
+end
 
-injectivity_radius(M::MMT, args...) where {MMT<:MetricManifold} =
-    injectivity_radius(base_manifold(M), args...)
+function injectivity_radius(M::MMT, args...) where {MMT<:MetricManifold}
+    return injectivity_radius(base_manifold(M), args...)
+end
 
 @doc doc"""
     inverse_local_metric(M::MetricManifold, x)
@@ -249,14 +265,18 @@ falls back to just be called with `MM.MM` such that the [`Manifold`](@ref) `MM.M
 implicitly has the metric `MM.G`, for example if this was the first one
 implemented or is the one most commonly assumed to be used.
 """
-is_default_metric(M::MMT) where {MMT<:MetricManifold} =
-    is_default_metric(base_manifold(M), metric(M))
-convert(T::Type{MetricManifold{MT,GT}}, M::MT) where {MT,GT} =
-    _convert_with_default(M, GT, is_default_metric(M, GT()))
-_convert_with_default(M::MT, T::Type{<:Metric}, ::Val{true}) where {MT<:Manifold} =
-    MetricManifold(M, T())
-_convert_with_default(M::MT, T::Type{<:Metric}, ::Val{false}) where {MT<:Manifold} =
+function is_default_metric(M::MMT) where {MMT<:MetricManifold}
+    return is_default_metric(base_manifold(M), metric(M))
+end
+function convert(T::Type{MetricManifold{MT,GT}}, M::MT) where {MT,GT}
+    return _convert_with_default(M, GT, is_default_metric(M, GT()))
+end
+function _convert_with_default(M::MT, T::Type{<:Metric}, ::Val{true}) where {MT<:Manifold}
+    return MetricManifold(M, T())
+end
+function _convert_with_default(M::MT, T::Type{<:Metric}, ::Val{false}) where {MT<:Manifold}
     error("Can not convert $(M) to a MetricManifold{$(MT),$(T)}, since $(T) is not the default metric.")
+end
 
 @doc doc"""
     inner(N::MetricManifold{M,G}, x, v, w)
@@ -272,10 +292,12 @@ g_x(v,w) = \langle v, G_x w\rangle,
 where $G_x$ is the local matrix representation of the [`Metric`](@ref) `G`.
 """
 inner(M::MMT, x, v, w) where {MMT<:MetricManifold} = inner(M, is_default_metric(M), x, v, w)
-inner(M::MMT, ::Val{false}, x, v, w) where {MMT<:MetricManifold} =
-    dot(v, local_metric(M, x) * w)
-inner(M::MMT, ::Val{true}, x, v, w) where {MMT<:MetricManifold} =
-    inner(base_manifold(M), x, v, w)
+function inner(M::MMT, ::Val{false}, x, v, w) where {MMT<:MetricManifold}
+    return dot(v, local_metric(M, x) * w)
+end
+function inner(M::MMT, ::Val{true}, x, v, w) where {MMT<:MetricManifold}
+    return inner(base_manifold(M), x, v, w)
+end
 function inner(
     B::VectorBundleFibers{<:CotangentSpaceType,MMT},
     x,
@@ -312,10 +334,12 @@ function local_metric_jacobian(M, x; backend = :default)
 end
 
 log!(M::MMT, w, x, y) where {MMT<:MetricManifold} = log!(M, is_default_metric(M), w, x, y)
-log!(M::MMT, ::Val{true}, w, x, y) where {MMT<:MetricManifold} =
-    log!(base_manifold(M), w, x, y)
-log!(M::MMT, ::Val{false}, w, x, y) where {MMT<:MetricManifold} =
+function log!(M::MMT, ::Val{true}, w, x, y) where {MMT<:MetricManifold}
+    return log!(base_manifold(M), w, x, y)
+end
+function log!(M::MMT, ::Val{false}, w, x, y) where {MMT<:MetricManifold}
     error("Logarithmic map not implemented on $(typeof(M)) for points $(typeof(x)) and $(typeof(y)).")
+end
 
 @doc doc"""
     log_local_metric_density(M::MetricManifold, x)
@@ -325,54 +349,65 @@ is given by $\rho=\log \sqrt{|\det [g_{ij}]|}$.
 """
 log_local_metric_density(M::MetricManifold, x) = log(abs(det_local_metric(M, x))) / 2
 
-mean!(
+function mean!(
     M::MMT,
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} = mean!(M, is_default_metric(M), y, x, w; kwargs...)
-mean!(
+) where {MMT<:MetricManifold}
+    return mean!(M, is_default_metric(M), y, x, w; kwargs...)
+end
+function mean!(
     M::MMT,
     ::Val{true},
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} = mean!(base_manifold(M), y, x, w; kwargs...)
-mean!(
+) where {MMT<:MetricManifold}
+    return mean!(base_manifold(M), y, x, w; kwargs...)
+end
+function mean!(
     M::MMT,
     ::Val{false},
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} = mean!(M, y, x, w, GradientDescentEstimation(); kwargs...)
+) where {MMT<:MetricManifold}
+    return mean!(M, y, x, w, GradientDescentEstimation(); kwargs...)
+end
 
-median!(
+function median!(
     M::MMT,
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} = median!(M, is_default_metric(M), y, x, w; kwargs...)
-median!(
+) where {MMT<:MetricManifold}
+    return median!(M, is_default_metric(M), y, x, w; kwargs...)
+end
+function median!(
     M::MMT,
     ::Val{true},
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} = median!(base_manifold(M), y, x, w; kwargs...)
-median!(
+) where {MMT<:MetricManifold}
+    return median!(base_manifold(M), y, x, w; kwargs...)
+end
+function median!(
     M::MMT,
     ::Val{false},
     y,
     x::AbstractVector,
     w::AbstractVector;
     kwargs...,
-) where {MMT<:MetricManifold} =
-    median!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
+) where {MMT<:MetricManifold}
+    return median!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
+end
 
 @doc doc"""
     metric(M::MetricManifold)
@@ -381,40 +416,55 @@ Get the metric $g$ of the manifold `M`.
 """
 metric(M::MetricManifold) = M.metric
 
-normal_tvector_distribution(M::MMT, x, σ) where {MMT<:MetricManifold} =
-    normal_tvector_distribution(M, is_default_metric(M), x, σ)
-normal_tvector_distribution(M::MMT, ::Val{true}, x, σ) where {MMT<:MetricManifold} =
-    normal_tvector_distribution(base_manifold(M), x, σ)
-normal_tvector_distribution(M::MMT, ::Val{false}, x, σ) where {MMT<:MetricManifold} =
+function normal_tvector_distribution(M::MMT, x, σ) where {MMT<:MetricManifold}
+    return normal_tvector_distribution(M, is_default_metric(M), x, σ)
+end
+function normal_tvector_distribution(M::MMT, ::Val{true}, x, σ) where {MMT<:MetricManifold}
+    return normal_tvector_distribution(base_manifold(M), x, σ)
+end
+function normal_tvector_distribution(M::MMT, ::Val{false}, x, σ) where {MMT<:MetricManifold}
     error("normal_tvector_distribution not implemented for a $(typeof(M)) at point $(typeof(x)) with standard deviation $(typeof(σ)).")
+end
 
-project_point!(M::MMT, y, x) where {MMT<:MetricManifold} =
-    project_point!(M, is_default_metric(M), y, x)
-project_point!(M::MMT, ::Val{true}, y, x) where {MMT<:MetricManifold} =
-    project_point!(base_manifold(M), y, x)
-project_point!(M::MMT, ::Val{false}, y, x) where {MMT<:MetricManifold} =
+function project_point!(M::MMT, y, x) where {MMT<:MetricManifold}
+    return project_point!(M, is_default_metric(M), y, x)
+end
+function project_point!(M::MMT, ::Val{true}, y, x) where {MMT<:MetricManifold}
+    return project_point!(base_manifold(M), y, x)
+end
+function project_point!(M::MMT, ::Val{false}, y, x) where {MMT<:MetricManifold}
     error("project_point! not implemented on $(typeof(M)) for point $(typeof(x))")
+end
 
-project_tangent!(M::MMT, w, x, v) where {MMT<:MetricManifold} =
-    project_tangent!(M, is_default_metric(M), w, x, v)
-project_tangent!(M::MMT, ::Val{true}, w, x, v) where {MMT<:MetricManifold} =
-    project_tangent!(base_manifold(M), w, x, v)
-project_tangent!(M::MMT, ::Val{false}, w, x, v) where {MMT<:MetricManifold} =
+function project_tangent!(M::MMT, w, x, v) where {MMT<:MetricManifold}
+    return project_tangent!(M, is_default_metric(M), w, x, v)
+end
+function project_tangent!(M::MMT, ::Val{true}, w, x, v) where {MMT<:MetricManifold}
+    return project_tangent!(base_manifold(M), w, x, v)
+end
+function project_tangent!(M::MMT, ::Val{false}, w, x, v) where {MMT<:MetricManifold}
     error("project_tangent! not implemented for a $(typeof(M)) and tangent $(typeof(v)) at point $(typeof(x)).")
+end
 
-projected_distribution(M::MMT, d, x) where {MMT<:MetricManifold} =
-    projected_distribution(M, is_default_metric(M), d, x)
-projected_distribution(M::MMT, ::Val{true}, d, x) where {MMT<:MetricManifold} =
-    projected_distribution(base_manifold(M), d, x)
-projected_distribution(M::MMT, ::Val{false}, d, x) where {MMT<:MetricManifold} =
+function projected_distribution(M::MMT, d, x) where {MMT<:MetricManifold}
+    return projected_distribution(M, is_default_metric(M), d, x)
+end
+function projected_distribution(M::MMT, ::Val{true}, d, x) where {MMT<:MetricManifold}
+    return projected_distribution(base_manifold(M), d, x)
+end
+function projected_distribution(M::MMT, ::Val{false}, d, x) where {MMT<:MetricManifold}
     error("projected_distribution not implemented for a $(typeof(M)) and with $(typeof(d)) at point $(typeof(x)).")
+end
 
-projected_distribution(M::MMT, d) where {MMT<:MetricManifold} =
-    projected_distribution(M, is_default_metric(M), d)
-projected_distribution(M::MMT, ::Val{true}, d) where {MMT<:MetricManifold} =
-    projected_distribution(base_manifold(M), d)
-projected_distribution(M::MMT, ::Val{false}, d) where {MMT<:MetricManifold} =
+function projected_distribution(M::MMT, d) where {MMT<:MetricManifold}
+    return projected_distribution(M, is_default_metric(M), d)
+end
+function projected_distribution(M::MMT, ::Val{true}, d) where {MMT<:MetricManifold}
+    return projected_distribution(base_manifold(M), d)
+end
+function projected_distribution(M::MMT, ::Val{false}, d) where {MMT<:MetricManifold}
     error("projected_distribution not implemented for a $(typeof(M)) with $(typeof(d)).")
+end
 
 """
     ricci_curvature(M::MetricManifold, x; backend = :default)
@@ -506,19 +556,39 @@ function solve_exp_ode(M, x, v, tspan; kwargs...)
     error("solve_exp_ode not implemented on $(typeof(M)) for point $(typeof(x)), vector $(typeof(v)), and timespan $(typeof(tspan)). For a suitable default, enter `using OrdinaryDiffEq`.")
 end
 
-vector_transport_to!(
+function vector_transport_to!(
     M::MMT,
     vto,
     x,
     v,
     y,
     m::AbstractVectorTransportMethod,
-) where {MMT<:MetricManifold} =
-    vector_transport_to!(M, is_default_metric(M), vto, x, v, y, m)
-vector_transport_to!(M::MMT, ::Val{true}, vto, x, v, y, m) where {MMT<:MetricManifold} =
-    vector_transport_to!(base_manifold(M), vto, x, v, y, m)
-vector_transport_to!(M::MMT, ::Val{false}, vto, x, v, y, m) where {MMT<:MetricManifold} =
+) where {MMT<:MetricManifold}
+    return vector_transport_to!(M, is_default_metric(M), vto, x, v, y, m)
+end
+function vector_transport_to!(
+    M::MMT,
+    ::Val{true},
+    vto,
+    x,
+    v,
+    y,
+    m,
+) where {MMT<:MetricManifold}
+    return vector_transport_to!(base_manifold(M), vto, x, v, y, m)
+end
+function vector_transport_to!(
+    M::MMT,
+    ::Val{false},
+    vto,
+    x,
+    v,
+    y,
+    m,
+) where {MMT<:MetricManifold}
     error("vector transport from a point of type $(typeof(x)) to a type $(typeof(y)) on a $(typeof(M)) for a vector of type $(v) and the $(typeof(m)) not yet implemented.")
+end
 
-zero_tangent_vector!(M::MMT, v, x) where {MMT<:MetricManifold} =
-    zero_tangent_vector!(M.manifold, v, x)
+function zero_tangent_vector!(M::MMT, v, x) where {MMT<:MetricManifold}
+    return zero_tangent_vector!(M.manifold, v, x)
+end

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -49,6 +49,7 @@ abstract type RiemannianMetric <: Metric end
 function check_manifold_point(M::MetricManifold, x; kwargs...)
     return check_manifold_point(M.manifold, x; kwargs...)
 end
+
 function check_tangent_vector(M::MetricManifold, x, v; kwargs...)
     return check_tangent_vector(M.manifold, x, v; kwargs...)
 end
@@ -147,7 +148,7 @@ Currently, the numerical integration is only accurate when using a single
 coordinate chart that covers the entire manifold. This excludes coordinates
 in an embedded space.
 """
-exp(::MetricManifold, ::Any)
+exp(::MetricManifold, ::Any...)
 function exp(M::MMT, x, v, T::AbstractVector{T} where {T}) where {MMT<:MetricManifold}
     return exp(M, is_default_metric(M), x, v, T)
 end
@@ -196,6 +197,7 @@ w^\flat = G_xw,
 where $G_x$ is the local matrix representation of `G`, see [`local_metric`](@ref)
 """
 flat(::MetricManifold, ::Any...)
+
 function flat!(M::MMT, v::CoTFVector, x, w::TFVector) where {MMT<:MetricManifold}
     g = local_metric(M, x)
     copyto!(v.data, g * w.data)
@@ -262,9 +264,11 @@ implemented or is the one most commonly assumed to be used.
 function is_default_metric(M::MMT) where {MMT<:MetricManifold}
     return is_default_metric(base_manifold(M), metric(M))
 end
+
 function convert(T::Type{MetricManifold{MT,GT}}, M::MT) where {MT,GT}
     return _convert_with_default(M, GT, is_default_metric(M, GT()))
 end
+
 function _convert_with_default(M::MT, T::Type{<:Metric}, ::Val{true}) where {MT<:Manifold}
     return MetricManifold(M, T())
 end
@@ -449,7 +453,6 @@ end
 function projected_distribution(M::MMT, ::Val{false}, d, x) where {MMT<:MetricManifold}
     error("projected_distribution not implemented for a $(typeof(M)) and with $(typeof(d)) at point $(typeof(x)).")
 end
-
 function projected_distribution(M::MMT, d) where {MMT<:MetricManifold}
     return projected_distribution(M, is_default_metric(M), d)
 end
@@ -517,6 +520,7 @@ where $G_x$ is the local matrix representation of `G`, i.e. one employs
 [`inverse_local_metric`](@ref) here to obtain $G_x^{-1}$.
 """
 sharp(::MetricManifold, ::Any)
+
 function sharp!(M::N, v::TFVector, x, w::CoTFVector) where {N<:MetricManifold}
     ginv = inverse_local_metric(M, x)
     copyto!(v.data, ginv * w.data)

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -196,12 +196,7 @@ w^\flat = G_xw,
 where $G_x$ is the local matrix representation of `G`, see [`local_metric`](@ref)
 """
 flat(::MetricManifold, ::Any...)
-function flat!(
-    M::MMT,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-) where {MMT<:MetricManifold}
+function flat!(M::MMT, v::CoTFVector, x, w::TFVector) where {MMT<:MetricManifold}
     g = local_metric(M, x)
     copyto!(v.data, g * w.data)
     return v
@@ -522,12 +517,7 @@ where $G_x$ is the local matrix representation of `G`, i.e. one employs
 [`inverse_local_metric`](@ref) here to obtain $G_x^{-1}$.
 """
 sharp(::MetricManifold, ::Any)
-function sharp!(
-    M::N,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-) where {N<:MetricManifold}
+function sharp!(M::N, v::TFVector, x, w::CoTFVector) where {N<:MetricManifold}
     ginv = inverse_local_metric(M, x)
     copyto!(v.data, ginv * w.data)
     return v

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -180,8 +180,7 @@ function exp!(M::MMT, ::Val{false}, y, x, v) where {MMT<:MetricManifold}
     tspan = (0.0, 1.0)
     sol = solve_exp_ode(M, x, v, tspan; dense = false, saveat = [1.0])
     n = length(x)
-    y .= sol.u[1][n+1:end]
-    return y
+    return copyto!(y, sol.u[1][n+1:end])
 end
 
 @doc doc"""

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -4,7 +4,7 @@
 An abstract [`Manifold`](@ref) to represent manifolds that are build as powers
 of another [`Manifold`](@ref) `M` to the power `TSize`.
 """
-abstract type AbstractPowerManifold{M <: Manifold} <: Manifold end
+abstract type AbstractPowerManifold{M<:Manifold} <: Manifold end
 
 @doc doc"""
     PowerManifold{TM<:Manifold, TSize<:Tuple} <: AbstractPowerManifold
@@ -27,7 +27,7 @@ power manifolds might be faster if they are represented as [`ProductManifold`](@
 
 Generate the power manifold $M^{N_1 \times N_2 \times \dots \times N_n}$.
 """
-struct PowerManifold{TM, TSize} <: AbstractPowerManifold{TM}
+struct PowerManifold{TM,TSize} <: AbstractPowerManifold{TM}
     manifold::TM
 end
 
@@ -66,7 +66,8 @@ end
 
 Power distribution on manifold `M`, based on `distribution`.
 """
-struct PowerPointDistribution{TM<:AbstractPowerManifold, TD<:MPointDistribution, TX} <: MPointDistribution{TM}
+struct PowerPointDistribution{TM<:AbstractPowerManifold,TD<:MPointDistribution,TX} <:
+       MPointDistribution{TM}
     manifold::TM
     distribution::TD
     x::TX
@@ -81,9 +82,10 @@ bundle) of type `type` using the power distribution of `distr`.
 Vector space type and `x` can be automatically inferred from distribution `distr`.
 """
 struct PowerFVectorDistribution{
-        TSpace<:VectorBundleFibers{<:VectorSpaceType, <:AbstractPowerManifold},
-        TD<:FVectorDistribution, TX
-    } <: FVectorDistribution{TSpace, TX}
+    TSpace<:VectorBundleFibers{<:VectorSpaceType,<:AbstractPowerManifold},
+    TD<:FVectorDistribution,
+    TX,
+} <: FVectorDistribution{TSpace,TX}
     type::TSpace
     x::TX
     distribution::TD
@@ -156,7 +158,10 @@ function check_tangent_vector(M::AbstractPowerManifold, x, v; kwargs...)
     return nothing
 end
 
-function det_local_metric(M::MetricManifold{<:AbstractPowerManifold, PowerMetric}, x::AbstractArray)
+function det_local_metric(
+    M::MetricManifold{<:AbstractPowerManifold,PowerMetric},
+    x::AbstractArray,
+)
     result = one(eltype(x))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -19,10 +19,10 @@ power manifolds might be faster if they are represented as [`ProductManifold`](@
 
 Generate the power manifold $M^{N_1 \times N_2 \times \dots \times N_n}$.
 """
-struct PowerManifold{TM<:Manifold, TSize} <: Manifold
+struct PowerManifold{TM<:Manifold,TSize} <: Manifold
     manifold::TM
 end
-PowerManifold(M::Manifold, size::Int...) = PowerManifold{typeof(M), Tuple{size...}}(M)
+PowerManifold(M::Manifold, size::Int...) = PowerManifold{typeof(M),Tuple{size...}}(M)
 
 @doc doc"""
     PowerMetric <: Metric
@@ -46,7 +46,8 @@ end
 
 Power inverse retraction of `inverse_retractions`. Works on [`PowerManifold`](@ref)s.
 """
-struct InversePowerRetraction{TR<:AbstractInverseRetractionMethod} <: AbstractInverseRetractionMethod
+struct InversePowerRetraction{TR<:AbstractInverseRetractionMethod} <:
+       AbstractInverseRetractionMethod
     inverse_retraction::TR
 end
 
@@ -55,7 +56,8 @@ end
 
 Power distribution on manifold `M`, based on `distribution`.
 """
-struct PowerPointDistribution{TM<:PowerManifold, TD<:MPointDistribution, TX} <: MPointDistribution{TM}
+struct PowerPointDistribution{TM<:PowerManifold,TD<:MPointDistribution,TX} <:
+       MPointDistribution{TM}
     manifold::TM
     distribution::TD
     x::TX
@@ -70,9 +72,10 @@ bundle) of type `type` using the power distribution of `distr`.
 Vector space type and `x` can be automatically inferred from distribution `distr`.
 """
 struct PowerFVectorDistribution{
-        TSpace<:VectorBundleFibers{<:VectorSpaceType, <:PowerManifold},
-        TD<:FVectorDistribution, TX
-    } <: FVectorDistribution{TSpace, TX}
+    TSpace<:VectorBundleFibers{<:VectorSpaceType,<:PowerManifold},
+    TD<:FVectorDistribution,
+    TX,
+} <: FVectorDistribution{TSpace,TX}
     type::TSpace
     x::TX
     distribution::TD
@@ -86,15 +89,18 @@ The array `bases` stores bases corresponding to particular parts of the manifold
 
 The type parameter `F` denotes the [`AbstractNumbers`](@ref) that will be used as scalars.
 """
-struct PrecomputedPowerOrthonormalBasis{TB<:AbstractArray{<:AbstractPrecomputedOrthonormalBasis}, F} <: AbstractPrecomputedOrthonormalBasis{F}
+struct PrecomputedPowerOrthonormalBasis{
+    TB<:AbstractArray{<:AbstractPrecomputedOrthonormalBasis},
+    F,
+} <: AbstractPrecomputedOrthonormalBasis{F}
     bases::TB
 end
 
 function PrecomputedPowerOrthonormalBasis(
     bases::AbstractArray{<:AbstractPrecomputedOrthonormalBasis},
-    F::AbstractNumbers = ℝ
-) where N
-    return PrecomputedPowerOrthonormalBasis{typeof(bases), F}(bases)
+    F::AbstractNumbers = ℝ,
+) where {N}
+    return PrecomputedPowerOrthonormalBasis{typeof(bases),F}(bases)
 end
 
 """
@@ -108,8 +114,7 @@ The tolerance for the last test can be set using the `kwargs...`.
 function check_manifold_point(M::PowerManifold, x; kwargs...)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        imp = check_manifold_point(M.manifold,
-            _read(rep_size, x, i); kwargs...)
+        imp = check_manifold_point(M.manifold, _read(rep_size, x, i); kwargs...)
         imp === nothing || return imp
     end
     return nothing
@@ -131,20 +136,22 @@ function check_tangent_vector(M::PowerManifold, x, v; kwargs...)
     end
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        imp = check_tangent_vector(M.manifold,
+        imp = check_tangent_vector(
+            M.manifold,
             _read(rep_size, x, i),
-            _read(rep_size, v, i); kwargs...)
+            _read(rep_size, v, i);
+            kwargs...,
+        )
         imp === nothing || return imp
     end
     return nothing
 end
 
-function det_local_metric(M::MetricManifold{PowerManifold, PowerMetric}, x::AbstractArray)
+function det_local_metric(M::MetricManifold{PowerManifold,PowerMetric}, x::AbstractArray)
     result = one(eltype(x))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        result *= det_local_metric(M.manifold,
-            _read(rep_size, x, i))
+        result *= det_local_metric(M.manifold, _read(rep_size, x, i))
     end
     return result
 end
@@ -159,9 +166,7 @@ function distance(M::PowerManifold, x, y)
     sum_squares = zero(eltype(x))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        sum_squares += distance(M.manifold,
-            _read(rep_size, x, i),
-            _read(rep_size, y, i))^2
+        sum_squares += distance(M.manifold, _read(rep_size, x, i), _read(rep_size, y, i))^2
     end
     return sqrt(sum_squares)
 end
@@ -176,10 +181,12 @@ exp(::PowerManifold, ::Any...)
 function exp!(M::PowerManifold, y, x, v)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        exp!(M.manifold,
+        exp!(
+            M.manifold,
             _write(rep_size, y, i),
             _read(rep_size, x, i),
-            _read(rep_size, v, i))
+            _read(rep_size, v, i),
+        )
     end
     return y
 end
@@ -192,83 +199,91 @@ use the musical isomorphism to transform the tangent vector `w` from the tangent
 This can be done elementwise, so r every entry of `w` (and `x`) sparately
 """
 flat(::PowerManifold, ::Any...)
-function flat!(M::PowerManifold, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
+function flat!(
+    M::PowerManifold,
+    v::FVector{CotangentSpaceType},
+    x,
+    w::FVector{TangentSpaceType},
+)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        flat!(M.manifold,
+        flat!(
+            M.manifold,
             FVector(CotangentSpace, _write(rep_size, v.data, i)),
             _read(rep_size, x, i),
-            FVector(TangentSpace, _read(rep_size, w.data, i)))
+            FVector(TangentSpace, _read(rep_size, w.data, i)),
+        )
     end
     return v
 end
 
 function get_basis(M::PowerManifold, x, B::AbstractBasis)
     rep_size = representation_size(M.manifold)
-    vs = [get_basis(M.manifold, _read(rep_size, x, i), B)
-        for i in get_iterator(M)]
+    vs = [get_basis(M.manifold, _read(rep_size, x, i), B) for i in get_iterator(M)]
     return PrecomputedPowerOrthonormalBasis(vs)
 end
 
 function get_basis(M::PowerManifold, x, B::ArbitraryOrthonormalBasis)
-    return invoke(get_basis, Tuple{PowerManifold, Any, AbstractBasis}, M, x, B)
+    return invoke(get_basis, Tuple{PowerManifold,Any,AbstractBasis}, M, x, B)
 end
 
 function get_basis(M::PowerManifold, x, B::DiagonalizingOrthonormalBasis)
-    return invoke(get_basis, Tuple{PowerManifold, Any, AbstractBasis}, M, x, B)
+    return invoke(get_basis, Tuple{PowerManifold,Any,AbstractBasis}, M, x, B)
 end
 
 
 function get_coordinates(M::PowerManifold, x, v, B::ArbitraryOrthonormalBasis)
     rep_size = representation_size(M.manifold)
-    vs = [get_coordinates(M.manifold, _read(rep_size, x, i), _read(rep_size, v, i), B)
-        for i in get_iterator(M)]
+    vs = [
+        get_coordinates(M.manifold, _read(rep_size, x, i), _read(rep_size, v, i), B)
+        for i in get_iterator(M)
+    ]
     return reduce(vcat, reshape(vs, length(vs)))
 end
 function get_coordinates(M::PowerManifold, x, v, B::PrecomputedPowerOrthonormalBasis)
     rep_size = representation_size(M.manifold)
-    vs = [get_coordinates(M.manifold, _read(rep_size, x, i), _read(rep_size, v, i), B.bases[i...])
-        for i in get_iterator(M)]
+    vs = [
+        get_coordinates(
+            M.manifold,
+            _read(rep_size, x, i),
+            _read(rep_size, v, i),
+            B.bases[i...],
+        )
+        for i in get_iterator(M)
+    ]
     return reduce(vcat, reshape(vs, length(vs)))
 end
 
-function get_iterator(M::PowerManifold{<:Manifold, Tuple{N}}) where N
+function get_iterator(M::PowerManifold{<:Manifold,Tuple{N}}) where {N}
     return 1:N
 end
-@generated function get_iterator(M::PowerManifold{<:Manifold, SizeTuple}) where SizeTuple
+@generated function get_iterator(M::PowerManifold{<:Manifold,SizeTuple}) where {SizeTuple}
     size_tuple = size_to_tuple(SizeTuple)
     return Base.product(map(Base.OneTo, size_tuple)...)
 end
 
-function get_vector(
-    M::PowerManifold,
-    x,
-    v,
-    B::PrecomputedPowerOrthonormalBasis
-)
+function get_vector(M::PowerManifold, x, v, B::PrecomputedPowerOrthonormalBasis)
     dim = manifold_dimension(M.manifold)
 
     rep_size = representation_size(M.manifold)
     v_out = similar(x)
     v_iter = 1
     for i in get_iterator(M)
-        copyto!(_write(rep_size, v_out, i), get_vector(
-            M.manifold,
-            _read(rep_size, x, i),
-            v[v_iter:v_iter+dim-1],
-            B.bases[i...]
-        ))
+        copyto!(
+            _write(rep_size, v_out, i),
+            get_vector(
+                M.manifold,
+                _read(rep_size, x, i),
+                v[v_iter:v_iter+dim-1],
+                B.bases[i...],
+            ),
+        )
         v_iter += dim
     end
     return v_out
 end
 
-function get_vector(
-    M::PowerManifold,
-    x,
-    v,
-    B::ArbitraryOrthonormalBasis
-)
+function get_vector(M::PowerManifold, x, v, B::ArbitraryOrthonormalBasis)
 
     dim = manifold_dimension(M.manifold)
 
@@ -276,12 +291,10 @@ function get_vector(
     v_out = similar(x)
     v_iter = 1
     for i in get_iterator(M)
-        copyto!(_write(rep_size, v_out, i), get_vector(
-            M.manifold,
-            _read(rep_size, x, i),
-            v[v_iter:v_iter+dim-1],
-            B
-        ))
+        copyto!(
+            _write(rep_size, v_out, i),
+            get_vector(M.manifold, _read(rep_size, x, i), v[v_iter:v_iter+dim-1], B),
+        )
         v_iter += dim
     end
     return v_out
@@ -299,8 +312,7 @@ function injectivity_radius(M::PowerManifold, x)
     initialized = false
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        cur_rad = injectivity_radius(M.manifold,
-            _read(rep_size, x, i))
+        cur_rad = injectivity_radius(M.manifold, _read(rep_size, x, i))
         if initialized
             radius = min(cur_rad, radius)
         else
@@ -324,11 +336,13 @@ inverse_retract(::PowerManifold, ::Any...)
 function inverse_retract!(M::PowerManifold, v, x, y, method::InversePowerRetraction)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        inverse_retract!(M.manifold,
+        inverse_retract!(
+            M.manifold,
             _write(rep_size, v, i),
             _read(rep_size, x, i),
             _read(rep_size, y, i),
-            method.inverse_retraction)
+            method.inverse_retraction,
+        )
     end
     return v
 end
@@ -345,24 +359,24 @@ function inner(M::PowerManifold, x, v, w)
     result = zero(eltype(v))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        result += inner(M.manifold,
+        result += inner(
+            M.manifold,
             _read(rep_size, x, i),
             _read(rep_size, v, i),
-            _read(rep_size, w, i))
+            _read(rep_size, w, i),
+        )
     end
     return result
 end
 
-is_default_metric(::PowerManifold,::PowerMetric) = Val(true)
+is_default_metric(::PowerManifold, ::PowerMetric) = Val(true)
 
 function isapprox(M::PowerManifold, x, y; kwargs...)
     result = true
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        result &= isapprox(M.manifold,
-            _read(rep_size, x, i),
-            _read(rep_size, y, i);
-            kwargs...)
+        result &=
+            isapprox(M.manifold, _read(rep_size, x, i), _read(rep_size, y, i); kwargs...)
     end
     return result
 end
@@ -370,11 +384,13 @@ function isapprox(M::PowerManifold, x, v, w; kwargs...)
     result = true
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        result &= isapprox(M.manifold,
+        result &= isapprox(
+            M.manifold,
             _read(rep_size, x, i),
             _read(rep_size, v, i),
             _read(rep_size, w, i);
-            kwargs...)
+            kwargs...,
+        )
     end
     return result
 end
@@ -389,10 +405,12 @@ log(::PowerManifold, ::Any...)
 function log!(M::PowerManifold, v, x, y)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        log!(M.manifold,
+        log!(
+            M.manifold,
             _write(rep_size, v, i),
             _read(rep_size, x, i),
-            _read(rep_size, y, i))
+            _read(rep_size, y, i),
+        )
     end
     return v
 end
@@ -410,8 +428,8 @@ $\mathcal M$, the manifold is of dimension
 d_{\mathcal N} = d_{\mathcal M}\prod_{i=1}^d n_i = n_1n_2\cdot\ldots\cdotn_dd_{\mathcal M}.
 ````
 """
-function manifold_dimension(M::PowerManifold{<:Manifold, TSize}) where TSize
-    return manifold_dimension(M.manifold)*prod(size_to_tuple(TSize))
+function manifold_dimension(M::PowerManifold{<:Manifold,TSize}) where {TSize}
+    return manifold_dimension(M.manifold) * prod(size_to_tuple(TSize))
 end
 
 @doc doc"""
@@ -424,9 +442,7 @@ function norm(M::PowerManifold, x, v)
     sum_squares = zero(eltype(v))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        sum_squares += norm(M.manifold,
-            _read(rep_size, x, i),
-            _read(rep_size, v, i))^2
+        sum_squares += norm(M.manifold, _read(rep_size, x, i), _read(rep_size, v, i))^2
     end
     return sqrt(sum_squares)
 end
@@ -452,9 +468,7 @@ end
 function _rand!(rng::AbstractRNG, d::PowerPointDistribution, x::AbstractArray)
     rep_size = representation_size(d.manifold.manifold)
     for i in get_iterator(d.manifold)
-        _rand!(rng,
-            d.distribution,
-            _write(rep_size, x, i))
+        _rand!(rng, d.distribution, _write(rep_size, x, i))
     end
     return x
 end
@@ -474,7 +488,7 @@ end
     return ntuple(i -> Colon(), N)
 end
 
-function representation_size(M::PowerManifold{<:Manifold, TSize}) where TSize
+function representation_size(M::PowerManifold{<:Manifold,TSize}) where {TSize}
     return (representation_size(M.manifold)..., size_to_tuple(TSize)...)
 end
 
@@ -490,11 +504,13 @@ retract(::PowerManifold, ::Any...)
 function retract!(M::PowerManifold, y, x, v, method::PowerRetraction)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        retract!(M.manifold,
+        retract!(
+            M.manifold,
             _write(rep_size, y, i),
             _read(rep_size, x, i),
             _read(rep_size, v, i),
-            method.retraction)
+            method.retraction,
+        )
     end
     return y
 end
@@ -507,13 +523,20 @@ Use the musical isomorphism to transform the cotangent vector `w` from the tange
 This can be done elementwise, so for every entry of `w` (and `x`) sparately
 """
 sharp(::PowerManifold, ::Any...)
-function sharp!(M::PowerManifold, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
+function sharp!(
+    M::PowerManifold,
+    v::FVector{TangentSpaceType},
+    x,
+    w::FVector{CotangentSpaceType},
+)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        sharp!(M.manifold,
+        sharp!(
+            M.manifold,
             FVector(TangentSpace, _write(rep_size, v.data, i)),
             _read(rep_size, x, i),
-            FVector(CotangentSpace, _read(rep_size, w.data, i)))
+            FVector(CotangentSpace, _read(rep_size, w.data, i)),
+        )
     end
     return v
 end

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -131,9 +131,7 @@ The tolerance for the last test can be set using the `kwargs...`.
 """
 function check_tangent_vector(M::PowerManifold, x, v; kwargs...)
     mpe = check_manifold_point(M, x)
-    if mpe !== nothing
-        return mpe
-    end
+    mpe === nothing || return mpe
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         imp = check_tangent_vector(
@@ -254,9 +252,7 @@ function get_coordinates(M::PowerManifold, x, v, B::PrecomputedPowerOrthonormalB
     return reduce(vcat, reshape(vs, length(vs)))
 end
 
-function get_iterator(M::PowerManifold{<:Manifold,Tuple{N}}) where {N}
-    return 1:N
-end
+get_iterator(M::PowerManifold{<:Manifold,Tuple{N}}) where {N} = 1:N
 @generated function get_iterator(M::PowerManifold{<:Manifold,SizeTuple}) where {SizeTuple}
     size_tuple = size_to_tuple(SizeTuple)
     return Base.product(map(Base.OneTo, size_tuple)...)
@@ -284,7 +280,6 @@ function get_vector(M::PowerManifold, x, v, B::PrecomputedPowerOrthonormalBasis)
 end
 
 function get_vector(M::PowerManifold, x, v, B::ArbitraryOrthonormalBasis)
-
     dim = manifold_dimension(M.manifold)
 
     rep_size = representation_size(M.manifold)
@@ -544,9 +539,7 @@ end
 support(tvd::PowerFVectorDistribution) = FVectorSupport(tvd.type, tvd.x)
 support(d::PowerPointDistribution) = MPointSupport(d.manifold)
 
-@inline function _write(rep_size::Tuple, x::AbstractArray, i::Int)
-    return _write(rep_size, x, (i,))
-end
+@inline _write(rep_size::Tuple, x::AbstractArray, i::Int) = _write(rep_size, x, (i,))
 @inline function _write(rep_size::Tuple, x::AbstractArray, i::Tuple)
     return view(x, rep_size_to_colons(rep_size)..., i...)
 end

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -197,12 +197,7 @@ use the musical isomorphism to transform the tangent vector `w` from the tangent
 This can be done elementwise, so r every entry of `w` (and `x`) sparately
 """
 flat(::PowerManifold, ::Any...)
-function flat!(
-    M::PowerManifold,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
+function flat!(M::PowerManifold, v::CoTFVector, x, w::TFVector)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         flat!(
@@ -518,12 +513,7 @@ Use the musical isomorphism to transform the cotangent vector `w` from the tange
 This can be done elementwise, so for every entry of `w` (and `x`) sparately
 """
 sharp(::PowerManifold, ::Any...)
-function sharp!(
-    M::PowerManifold,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
+function sharp!(M::PowerManifold, v::TFVector, x, w::CoTFVector)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         sharp!(

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -22,6 +22,7 @@ Generate the power manifold $M^{N_1 \times N_2 \times \dots \times N_n}$.
 struct PowerManifold{TM<:Manifold,TSize} <: Manifold
     manifold::TM
 end
+
 PowerManifold(M::Manifold, size::Int...) = PowerManifold{typeof(M),Tuple{size...}}(M)
 
 @doc doc"""
@@ -41,6 +42,7 @@ Power retraction based on `retraction`. Works on [`PowerManifold`](@ref)s.
 struct PowerRetraction{TR<:AbstractRetractionMethod} <: AbstractRetractionMethod
     retraction::TR
 end
+
 """
     InversePowerRetraction(inverse_retractions::AbstractInverseRetractionMethod...)
 
@@ -82,7 +84,10 @@ struct PowerFVectorDistribution{
 end
 
 """
-    PrecomputedPowerOrthonormalBasis(bases::AbstractArray{AbstractPrecomputedOrthonormalBasis}, F::AbstractNumbers = ℝ)
+    PrecomputedPowerOrthonormalBasis(
+        bases::AbstractArray{AbstractPrecomputedOrthonormalBasis},
+        F::AbstractNumbers = ℝ,
+    )
 
 A precomputed orthonormal basis of a tangent space of a power manifold.
 The array `bases` stores bases corresponding to particular parts of the manifold.
@@ -176,6 +181,7 @@ Compute the exponential map from `x` in direction `v` on the [`PowerManifold`](@
 which can be computed using the base manifolds exponential map elementwise.
 """
 exp(::PowerManifold, ::Any...)
+
 function exp!(M::PowerManifold, y, x, v)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -197,6 +203,7 @@ use the musical isomorphism to transform the tangent vector `w` from the tangent
 This can be done elementwise, so r every entry of `w` (and `x`) sparately
 """
 flat(::PowerManifold, ::Any...)
+
 function flat!(M::PowerManifold, v::CoTFVector, x, w::TFVector)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -215,15 +222,12 @@ function get_basis(M::PowerManifold, x, B::AbstractBasis)
     vs = [get_basis(M.manifold, _read(rep_size, x, i), B) for i in get_iterator(M)]
     return PrecomputedPowerOrthonormalBasis(vs)
 end
-
 function get_basis(M::PowerManifold, x, B::ArbitraryOrthonormalBasis)
     return invoke(get_basis, Tuple{PowerManifold,Any,AbstractBasis}, M, x, B)
 end
-
 function get_basis(M::PowerManifold, x, B::DiagonalizingOrthonormalBasis)
     return invoke(get_basis, Tuple{PowerManifold,Any,AbstractBasis}, M, x, B)
 end
-
 
 function get_coordinates(M::PowerManifold, x, v, B::ArbitraryOrthonormalBasis)
     rep_size = representation_size(M.manifold)
@@ -273,7 +277,6 @@ function get_vector(M::PowerManifold, x, v, B::PrecomputedPowerOrthonormalBasis)
     end
     return v_out
 end
-
 function get_vector(M::PowerManifold, x, v, B::ArbitraryOrthonormalBasis)
     dim = manifold_dimension(M.manifold)
 
@@ -323,6 +326,7 @@ of the base manifold. Then this method is performed elementwise, so the encapsul
 retraction method has to be one that is available on the base [`Manifold`](@ref).
 """
 inverse_retract(::PowerManifold, ::Any...)
+
 function inverse_retract!(M::PowerManifold, v, x, y, method::InversePowerRetraction)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -392,6 +396,7 @@ Compute the logarithmic map from `x` to `y` on the [`PowerManifold`](@ref) `M`,
 which can be computed using the base manifolds logarithmic map elementwise.
 """
 log(::PowerManifold, ::Any...)
+
 function log!(M::PowerManifold, v, x, y)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -447,6 +452,7 @@ function rand(rng::AbstractRNG, d::PowerPointDistribution)
     _rand!(rng, d, x)
     return x
 end
+
 function _rand!(rng::AbstractRNG, d::PowerFVectorDistribution, v::AbstractArray)
     rep_size = representation_size(d.type.M.manifold)
     for i in get_iterator(d.type.M)
@@ -491,6 +497,7 @@ base manifold. Then this method is performed elementwise, so the encapsulated re
 method has to be one that is available on the base [`Manifold`](@ref).
 """
 retract(::PowerManifold, ::Any...)
+
 function retract!(M::PowerManifold, y, x, v, method::PowerRetraction)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -513,6 +520,7 @@ Use the musical isomorphism to transform the cotangent vector `w` from the tange
 This can be done elementwise, so for every entry of `w` (and `x`) sparately
 """
 sharp(::PowerManifold, ::Any...)
+
 function sharp!(M::PowerManifold, v::TFVector, x, w::CoTFVector)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -60,8 +60,9 @@ Product retraction of `retractions`. Works on [`ProductManifold`](@ref).
 struct ProductRetraction{TR<:Tuple} <: AbstractRetractionMethod
     retractions::TR
 end
-ProductRetraction(retractions::AbstractRetractionMethod...) =
-    ProductRetraction{typeof(retractions)}(retractions)
+function ProductRetraction(retractions::AbstractRetractionMethod...)
+    return ProductRetraction{typeof(retractions)}(retractions)
+end
 
 """
     InverseProductRetraction(retractions::AbstractInverseRetractionMethod...)
@@ -71,8 +72,9 @@ Product inverse retraction of `inverse retractions`. Works on [`ProductManifold`
 struct InverseProductRetraction{TR<:Tuple} <: AbstractInverseRetractionMethod
     inverse_retractions::TR
 end
-InverseProductRetraction(inverse_retractions::AbstractInverseRetractionMethod...) =
-    InverseProductRetraction{typeof(inverse_retractions)}(inverse_retractions)
+function InverseProductRetraction(inverse_retractions::AbstractInverseRetractionMethod...)
+    return InverseProductRetraction{typeof(inverse_retractions)}(inverse_retractions)
+end
 
 """
     PrecomputedProductOrthonormalBasis(parts::NTuple{N,AbstractPrecomputedOrthonormalBasis} where N, F::AbstractNumbers = ℝ)
@@ -473,13 +475,14 @@ Compute the norm of `v` from the tangent space of `x` on the [`ProductManifold`]
 i.e. from the element wise norms the 2-norm is computed.
 """
 function norm(M::ProductManifold, x, v)
-    norms_squared =
+    norms_squared = (
         map(
             norm,
             M.manifolds,
             submanifold_components(M, x),
             submanifold_components(M, v),
         ) .^ 2
+    )
     return sqrt(sum(norms_squared))
 end
 
@@ -504,8 +507,9 @@ end
 function ProductFVectorDistribution(distributions::FVectorDistribution...)
     M = ProductManifold(map(d -> support(d).space.M, distributions)...)
     VS = support(distributions[1]).space.VS
-    all(d -> support(d).space.VS == VS, distributions) ||
-    error("Not all distributions have support in vector spaces of the same type, which is currently not supported")
+    if !all(d -> support(d).space.VS == VS, distributions)
+        error("Not all distributions have support in vector spaces of the same type, which is currently not supported")
+    end
     # Probably worth considering sum spaces in the future?
     x = ProductRepr(map(d -> support(d).x, distributions)...)
     return ProductFVectorDistribution(VectorBundleFibers(VS, M), x, distributions...)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -234,12 +234,7 @@ use the musical isomorphism to transform the tangent vector `w` from the tangent
 This can be done elementwise, so for every entry of `w` (and `x`) sparately
 """
 flat(::ProductManifold, ::Any...)
-function flat!(
-    M::ProductManifold,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
+function flat!(M::ProductManifold, v::CoTFVector, x, w::TFVector)
     vfs = map(u -> FVector(CotangentSpace, u), submanifold_components(v))
     wfs = map(u -> FVector(TangentSpace, u), submanifold_components(w))
     map(flat!, M.manifolds, vfs, submanifold_components(M, x), wfs)
@@ -575,12 +570,7 @@ Use the musical isomorphism to transform the cotangent vector `w` from the tange
 This can be done elementwise, so vor every entry of `w` (and `x`) sparately
 """
 sharp(::ProductManifold, ::Any...)
-function sharp!(
-    M::ProductManifold,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
+function sharp!(M::ProductManifold, v::TFVector, x, w::CoTFVector)
     vfs = map(u -> FVector(TangentSpace, u), submanifold_components(v))
     wfs = map(u -> FVector(CotangentSpace, u), submanifold_components(w))
     map(sharp!, M.manifolds, vfs, submanifold_components(M, x), wfs)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -171,15 +171,9 @@ For the case that more than one is a product manifold of these is build with the
 same approach as above
 """
 cross(::Manifold...)
-function cross(M1::Manifold, M2::Manifold)
-    return ProductManifold(M1, M2)
-end
-function cross(M1::ProductManifold, M2::Manifold)
-    return ProductManifold(M1.manifolds..., M2)
-end
-function cross(M1::Manifold, M2::ProductManifold)
-    return ProductManifold(M1, M2.manifolds...)
-end
+cross(M1::Manifold, M2::Manifold) = ProductManifold(M1, M2)
+cross(M1::ProductManifold, M2::Manifold) = ProductManifold(M1.manifolds..., M2)
+cross(M1::Manifold, M2::ProductManifold) = ProductManifold(M1, M2.manifolds...)
 function cross(M1::ProductManifold, M2::ProductManifold)
     return ProductManifold(M1.manifolds..., M2.manifolds...)
 end
@@ -370,9 +364,7 @@ injectivity_radius(::ProductManifold, ::Any...)
 function injectivity_radius(M::ProductManifold, x)
     return min(map(injectivity_radius, M.manifolds, submanifold_components(M, x))...)
 end
-function injectivity_radius(M::ProductManifold)
-    return min(map(injectivity_radius, M.manifolds)...)
-end
+injectivity_radius(M::ProductManifold) = min(map(injectivity_radius, M.manifolds)...)
 
 @doc doc"""
     inner(M::ProductManifold, x, v, w)
@@ -531,8 +523,7 @@ function rand(rng::AbstractRNG, d::ProductFVectorDistribution)
 end
 
 function _rand!(rng::AbstractRNG, d::ProductPointDistribution, x::AbstractArray{<:Number})
-    x .= rand(rng, d)
-    return x
+    return copyto!(x, rand(rng, d))
 end
 function _rand!(rng::AbstractRNG, d::ProductPointDistribution, x::ProductRepr)
     map(
@@ -543,8 +534,7 @@ function _rand!(rng::AbstractRNG, d::ProductPointDistribution, x::ProductRepr)
     return x
 end
 function _rand!(rng::AbstractRNG, d::ProductFVectorDistribution, v::AbstractArray{<:Number})
-    v .= rand(rng, d)
-    return v
+    return copyto!(v, rand(rng, d))
 end
 function _rand!(rng::AbstractRNG, d::ProductFVectorDistribution, v::ProductRepr)
     map(t -> _rand!(rng, t[1], t[2]), d.distributions, submanifold_components(d.space.M, v))
@@ -602,9 +592,7 @@ end
 
 Extract the `i`th factor of the product manifold `M`.
 """
-function submanifold(M::ProductManifold, i::Integer)
-    return M.manifolds[i]
-end
+submanifold(M::ProductManifold, i::Integer) = M.manifolds[i]
 
 """
     submanifold(M::ProductManifold, i::Val)
@@ -613,9 +601,7 @@ Extract the factor of the product manifold `M` indicated by indices in `i`.
 For example, for `i` equal to `Val((1, 3))` the product manifold constructed
 from the first and the third factor is returned.
 """
-function submanifold(M::ProductManifold, i::Val)
-    return ProductManifold(select_from_tuple(M.manifolds, i))
-end
+submanifold(M::ProductManifold, i::Val) = ProductManifold(select_from_tuple(M.manifolds, i))
 
 """
     submanifold(M::ProductManifold, i::AbstractVector)
@@ -629,9 +615,7 @@ This function is not type-stable, for better preformance use
 """
 submanifold(M::ProductManifold, i::AbstractVector) = submanifold(M, Val(tuple(i...)))
 
-function support(d::ProductPointDistribution)
-    return MPointSupport(d.manifold)
-end
+support(d::ProductPointDistribution) = MPointSupport(d.manifold)
 
 function support(tvd::ProductFVectorDistribution)
     return FVectorSupport(

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -240,8 +240,8 @@ function flat!(
     x,
     w::FVector{TangentSpaceType},
 )
-    vfs = map(u -> FVector(CotangentSpace, u), submanifold_components(M, v.data))
-    wfs = map(u -> FVector(TangentSpace, u), submanifold_components(M, w.data))
+    vfs = map(u -> FVector(CotangentSpace, u), submanifold_components(v))
+    wfs = map(u -> FVector(TangentSpace, u), submanifold_components(w))
     map(flat!, M.manifolds, vfs, submanifold_components(M, x), wfs)
     return v
 end
@@ -581,8 +581,8 @@ function sharp!(
     x,
     w::FVector{CotangentSpaceType},
 )
-    vfs = map(u -> FVector(TangentSpace, u), submanifold_components(M, v.data))
-    wfs = map(u -> FVector(CotangentSpace, u), submanifold_components(M, w.data))
+    vfs = map(u -> FVector(TangentSpace, u), submanifold_components(v))
+    wfs = map(u -> FVector(CotangentSpace, u), submanifold_components(w))
     map(sharp!, M.manifolds, vfs, submanifold_components(M, x), wfs)
     return v
 end

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -237,14 +237,7 @@ function exp!(M::Rotations{4}, y, x, v)
     return y
 end
 
-function flat!(
-    M::Rotations,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
-    return copyto!(v, w)
-end
+flat!(M::Rotations, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_coordinates(M::Rotations, x, v, B::ArbitraryOrthonormalBasis) where {N}
     T = Base.promote_eltype(x, v)
@@ -585,14 +578,7 @@ $\mathrm{SO}(n)$ it's `(n,n)`.
 """
 representation_size(::Rotations{N}) where {N} = (N, N)
 
-function sharp!(
-    M::Rotations,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
-    return copyto!(v, w)
-end
+sharp!(M::Rotations, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 function rand(
     rng::AbstractRNG,

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -11,6 +11,7 @@ real-valued orthogonal matrices with determinant $+1$.
 Generate the $\mathrm{SO}(n) \subset \mathbb R^{n\times n}$
 """
 struct Rotations{N} <: Manifold end
+
 Rotations(n::Int) = Rotations{n}()
 
 """
@@ -27,6 +28,7 @@ struct NormalRotationDistribution{TResult,TM<:Rotations,TD<:Distribution} <:
     manifold::TM
     distr::TD
 end
+
 function NormalRotationDistribution(
     M::Rotations,
     d::Distribution,
@@ -145,10 +147,7 @@ Compute the exponential map on the [`Rotations`](@ref) from `x` into direction
 ````
 
 where $\operatorname{Exp}(v)$  denotes the matrix exponential of $v$.
-"""
-exp(::Rotations, ::Any...)
 
-@doc doc"""
     exp(M::Rotations{4}, x, v)
 
 Compute the exponential map of tangent vector `v` at point `x` from $\mathrm{SO}(4)$
@@ -158,17 +157,17 @@ The algorithm used is a more numerically stable form of those proposed in
 [^Gallier2002] and [^Andrica2013].
 
 [^Gallier2002]:
-    > Gallier J.; Xu D.; Computing exponentials of skew-symmetric matrices
-    > and logarithms of orthogonal matrices.
-    > International Journal of Robotics and Automation (2002), 17(4), pp. 1-11.
-    > [pdf](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.35.3205).
+> Gallier J.; Xu D.; Computing exponentials of skew-symmetric matrices
+> and logarithms of orthogonal matrices.
+> International Journal of Robotics and Automation (2002), 17(4), pp. 1-11.
+> [pdf](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.35.3205).
 [^Andrica2013]:
-    > Andrica D.; Rohan R.-A.; Computing the Rodrigues coefficients of the
-    > exponential map of the Lie groups of matrices.
-    > Balkan Journal of Geometry and Its Applications (2013), 18(2), pp. 1-2.
-    > [pdf](https://www.emis.de/journals/BJGA/v18n2/B18-2-an.pdf).
+> Andrica D.; Rohan R.-A.; Computing the Rodrigues coefficients of the
+> exponential map of the Lie groups of matrices.
+> Balkan Journal of Geometry and Its Applications (2013), 18(2), pp. 1-2.
+> [pdf](https://www.emis.de/journals/BJGA/v18n2/B18-2-an.pdf).
 """
-exp(::Rotations{4}, ::Any...)
+exp(::Rotations, ::Any...)
 
 exp!(M::Rotations, y, x, v) = copyto!(y, x * exp(v))
 function exp!(M::Rotations{2}, y, x, v)
@@ -262,12 +261,14 @@ end
 hat!(M::Rotations{2}, Ω, x, ω) = hat!(M, Ω, x, ω[1])
 
 @doc doc"""
-    hat!(M::Rotations, Ω, x, ω)
+    hat(M::Rotations, x, ω)
 
 Convert the unique tangent vector components $\omega$ at point $x$ on rotations
 group $\mathrm{SO}(n)$ to the matrix representation $\Omega$ of the tangent
-vector. See [`vee!`](@ref) for the conventions used.
+vector. See [`vee`](@ref) for the conventions used.
 """
+hat(M::Rotations, ::Any...)
+
 function hat!(M::Rotations{N}, Ω, x, ω) where {N}
     @assert size(Ω) == (N, N)
     @assert length(ω) == manifold_dimension(M)
@@ -303,15 +304,13 @@ Return the injectivity radius on the [`Rotations`](@ref) `M`, which is globally
 ````math
     \operatorname{inj}_{\mathrm{SO}(n)}(x) = \pi\sqrt{2}.
 ````
-"""
-injectivity_radius(::Rotations) = π * sqrt(2.0)
 
-@doc doc"""
     injectivity_radius(M::Rotations, x, ::PolarRetraction)
 
 Return the radius of injectivity for the [`PolarRetraction`](@ref) on the
 [`Rotations`](@ref) `M` which is $\frac{\pi}{\sqrt{2}}$.
 """
+injectivity_radius(::Rotations) = π * sqrt(2.0)
 injectivity_radius(::Rotations, x, ::PolarRetraction) = π / sqrt(2.0)
 
 @doc doc"""
@@ -330,7 +329,7 @@ inner(M::Rotations, x, w, v) = dot(w, v)
 @doc doc"""
     inverse_retract(M, x, y, ::PolarInverseRetraction)
 
-Compute a vector from the tagent space $T_x\mathrm{SO}(n)$
+Compute a vector from the tangent space $T_x\mathrm{SO}(n)$
 of the point `x` on the [`Rotations`](@ref) manifold `M`
 with which the point `y` can be reached by the
 [`PolarRetraction`](@ref) from the point `x` after time 1.
@@ -344,8 +343,15 @@ The formula reads
 where $s$ is the solution to the Sylvester equation
 
 $x^{\mathrm{T}}ys + s(x^{\mathrm{T}}y)^{\mathrm{T}} + 2\mathrm{I}_n = 0.$
+
+    inverse_retract(M::Rotations, x, y, ::QRInverseRetraction)
+
+Compute a vector from the tangent space $T_x\mathrm{SO}(n)$ of the point `x` on the
+[`Rotations`](@ref) manifold `M` with which the point `y` can be reached by the
+[`QRRetraction`](@ref) from the point `x` after time 1.
 """
 inverse_retract(::Rotations, ::Any, ::Any, ::PolarInverseRetraction)
+
 function inverse_retract!(M::Rotations, v, x, y, method::PolarInverseRetraction)
     A = transpose(x) * y
     H = 2 * one(x)
@@ -362,15 +368,6 @@ function inverse_retract!(M::Rotations, v, x, y, method::PolarInverseRetraction)
     end
     return v
 end
-
-@doc doc"""
-    inverse_retract(M::Rotations, x, y, ::QRInverseRetraction)
-
-Compute a vector from the tagent space $T_x\mathrm{SO}(n)$ of the point `x` on the
-[`Rotations`](@ref) manifold `M` with which the point `y` can be reached by the
-[`QRRetraction`](@ref) from the point `x` after time 1.
-"""
-inverse_retract(::Rotations, ::Any, ::Any, ::QRInverseRetraction)
 function inverse_retract!(M::Rotations{N}, v, x, y, ::QRInverseRetraction) where {N}
     A = transpose(x) * y
     R = zero(v)
@@ -468,10 +465,10 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Rotations, ::Any)
+
 function mean!(M::Rotations, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 2 / √2); kwargs...)
 end
-
 
 @doc doc"""
     norm(M::Rotations, x, v)
@@ -568,6 +565,7 @@ Project the matrix `v` onto the tangent space by making `v` skew symmetric,
 where tangent vectors are represented by elements from the Lie group
 """
 project_tangent(::Rotations, ::Any...)
+
 project_tangent!(M::Rotations, w, x, v) = (w .= (v .- transpose(v)) ./ 2)
 
 @doc doc"""
@@ -591,6 +589,7 @@ function rand(
         return convert(TResult, _fix_random_rotation(A))
     end
 end
+
 function _rand!(
     rng::AbstractRNG,
     d::NormalRotationDistribution{TResult,Rotations{N}},
@@ -598,6 +597,7 @@ function _rand!(
 ) where {TResult,N}
     return copyto!(x, rand(rng, d))
 end
+
 function _fix_random_rotation(A::AbstractMatrix)
     s = diag(sign.(qr(A).R))
     D = Diagonal(s)
@@ -609,6 +609,14 @@ function _fix_random_rotation(A::AbstractMatrix)
 end
 
 @doc doc"""
+    retract(M, x, v)
+    retract(M, x, v, ::QRRetraction)
+
+Compute the SVD-based retraction on the [`Rotations`](@ref) `M` from `x` in direction `v`
+(as an element of the Lie group) and is a first-order approximation of the exponential map.
+
+This is also the default retraction on the [`Rotations`](@ref)
+
     retract(M::Rotations, x, v, ::PolarRetraction)
 
 Compute the SVD-based retraction on the [`Rotations`](@ref) `M` from `x` in direction `v`
@@ -625,23 +633,8 @@ be the singular value decomposition, then the formula reads
 \operatorname{retr}_x v = UV^\mathrm{T}.
 ````
 """
-retract(::Rotations, ::Any, ::Any, ::PolarRetraction)
-function retract!(M::Rotations, y, x, v, method::PolarRetraction)
-    A = x + x * v
-    return project_point!(M, y, A; check_det = false)
-end
+retract(::Rotations, ::Any...)
 
-@doc doc"""
-    retract(M, x, v)
-    retract(M, x, v, ::QRRetraction)
-
-
-Compute the SVD-based retraction on the [`Rotations`](@ref) `M` from `x` in direction `v`
-(as an element of the Lie group) and is a first-order approximation of the exponential map.
-
-This is also the default retraction on the [`Rotations`](@ref)
-"""
-retract(::Rotations, ::Any, ::Any, ::QRRetraction)
 function retract!(M::Rotations, y::AbstractArray{T}, x, v, method::QRRetraction) where {T}
     A = x + x * v
     qr_decomp = qr(A)
@@ -650,9 +643,13 @@ function retract!(M::Rotations, y::AbstractArray{T}, x, v, method::QRRetraction)
     return copyto!(y, qr_decomp.Q * D)
 end
 retract!(M::Rotations, y, x, v) = retract!(M, y, x, v, QRRetraction())
+function retract!(M::Rotations, y, x, v, method::PolarRetraction)
+    A = x + x * v
+    return project_point!(M, y, A; check_det = false)
+end
 
 @doc doc"""
-    vee!(M::Rotations, ω, x, Ω)
+    vee(M::Rotations, x, Ω)
 
 Extract the unique tangent vector components $\omega$ at point $x$ on rotations
 group $\mathrm{SO}(n)$ from the matrix representation $\Omega$ of the tangent
@@ -668,6 +665,8 @@ along the axis of rotation.
 For $\mathrm{SO}(n)$ where $n \ge 4$, the additional elements of $\omega$ are
 $\omega_{i (i - 3)/2 + j + 1} = \Omega_{ij}$, for $i \in [4, n], j \in [1,i)$.
 """
+vee(::Rotations, ::Any...)
+
 function vee!(M::Rotations{N}, ω, x, Ω) where {N}
     @assert size(Ω) == (N, N)
     @assert length(ω) == manifold_dimension(M)
@@ -696,4 +695,5 @@ Return the zero tangent vector from the tangent space art `x` on the [`Rotations
 as an element of the Lie group, i.e. the zero matrix.
 """
 zero_tangent_vector(M::Rotations, x) = zero(x)
+
 zero_tangent_vector!(M::Rotations, v, x) = fill!(v, 0)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra: norm
-
 @doc doc"""
     Rotations{N} <: Manifold
 

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -574,7 +574,7 @@ project_tangent!(M::Rotations, w, x, v) = (w .= (v .- transpose(v)) ./ 2)
 Return the `size()` of a point on the [`Rotations`](@ref) `M`, i.e. for the
 $\mathrm{SO}(n)$ it's `(n,n)`.
 """
-representation_size(::Rotations{N}) where {N} = (N, N)
+@generated representation_size(::Rotations{N}) where {N} = (N, N)
 
 sharp!(M::Rotations, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -243,8 +243,7 @@ function flat!(
     x,
     w::FVector{TangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 function get_coordinates(M::Rotations, x, v, B::ArbitraryOrthonormalBasis) where {N}
@@ -592,8 +591,7 @@ function sharp!(
     x,
     w::FVector{CotangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 function rand(

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -485,8 +485,9 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Rotations, ::Any)
-mean!(M::Rotations, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 2 / √2); kwargs...)
+function mean!(M::Rotations, y, x::AbstractVector, w::AbstractVector; kwargs...)
+    return mean!(M, y, x, w, GeodesicInterpolationWithinRadius(π / 2 / √2); kwargs...)
+end
 
 
 @doc doc"""

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -160,8 +160,9 @@ since $\langle x,v\rangle = 0$ and when $d_{\mathbb S^2}(x,y) \leq \frac{\pi}{2}
 ````
 """
 inverse_retract(::Sphere, ::Any, ::Any, ::ProjectionInverseRetraction)
-inverse_retract!(::Sphere, v, x, y, ::ProjectionInverseRetraction) =
-    (v .= y ./ dot(x, y) .- x)
+function inverse_retract!(::Sphere, v, x, y, ::ProjectionInverseRetraction)
+    return (v .= y ./ dot(x, y) .- x)
+end
 
 @doc doc"""
     log(M::Sphere, x, y)
@@ -219,8 +220,9 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Sphere, ::Any...)
-mean!(S::Sphere, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(S, y, x, w, GeodesicInterpolationWithinRadius(π / 2); kwargs...)
+function mean!(S::Sphere, y, x::AbstractVector, w::AbstractVector; kwargs...)
+    return mean!(S, y, x, w, GeodesicInterpolationWithinRadius(π / 2); kwargs...)
+end
 
 @doc doc"""
     norm(M::Sphere, x, v)

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -110,8 +110,7 @@ function exp!(M::Sphere, y, x, v)
 end
 
 function flat!(M::Sphere, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 @doc doc"""
@@ -306,8 +305,7 @@ function retract!(M::Sphere, y, x, v, ::ProjectionRetraction)
 end
 
 function sharp!(M::Sphere, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 """

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -13,18 +13,18 @@ Generate the $\mathbb S^{n}\subset \mathbb R^{n+1}$
 struct Sphere{N} <: Manifold end
 Sphere(n::Int) = Sphere{n}()
 
-function get_basis(M::Sphere{N}, x, B::DiagonalizingOrthonormalBasis) where N
-    A = zeros(N+1, N+1)
-    A[1,:] = transpose(x)
-    A[2,:] = transpose(B.v)
+function get_basis(M::Sphere{N}, x, B::DiagonalizingOrthonormalBasis) where {N}
+    A = zeros(N + 1, N + 1)
+    A[1, :] = transpose(x)
+    A[2, :] = transpose(B.v)
     V = nullspace(A)
     κ = ones(N)
     if !iszero(B.v)
         # if we have a nonzero direction for the geodesic, add it and it gets curvature zero from the tensor
-		V = cat(B.v/norm(M, x, B.v), V; dims=2)
+        V = cat(B.v / norm(M, x, B.v), V; dims = 2)
         κ[1] = 0.0 # no curvature along the geodesic direction, if x!=y
     end
-    vecs = [ V[:,i] for i in 1:N ]
+    vecs = [V[:, i] for i = 1:N]
     return PrecomputedDiagonalizingOrthonormalBasis(vecs, κ)
 end
 
@@ -35,12 +35,18 @@ Check whether `x` is a valid point on the [`Sphere`](@ref) `S`, i.e. is a vector
 of length [`manifold_dimension`](@ref)`(S)+1` (approximately) of unit length.
 The tolerance for the last test can be set using the `kwargs...`.
 """
-function check_manifold_point(S::Sphere{N},x; kwargs...) where {N}
+function check_manifold_point(S::Sphere{N}, x; kwargs...) where {N}
     if size(x) != representation_size(S)
-        return DomainError(size(x),"The point $(x) does not lie on $S, since its size is not $(N+1).")
+        return DomainError(
+            size(x),
+            "The point $(x) does not lie on $S, since its size is not $(N+1).",
+        )
     end
-    if !isapprox(norm(x), 1.; kwargs...)
-        return DomainError(norm(x), "The point $(x) does not lie on the sphere $(S) since its norm is not 1.")
+    if !isapprox(norm(x), 1.0; kwargs...)
+        return DomainError(
+            norm(x),
+            "The point $(x) does not lie on the sphere $(S) since its norm is not 1.",
+        )
     end
     return nothing
 end
@@ -53,16 +59,19 @@ after [`check_manifold_point`](@ref)`(S,x)`, `v` has to be of same dimension as 
 and orthogonal to `x`.
 The tolerance for the last test can be set using the `kwargs...`.
 """
-function check_tangent_vector(S::Sphere{N},x,v; kwargs...) where N
-    perr = check_manifold_point(S,x)
+function check_tangent_vector(S::Sphere{N}, x, v; kwargs...) where {N}
+    perr = check_manifold_point(S, x)
     perr === nothing || return perr
     if size(v) != representation_size(S)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $S since its size does not match $(N+1).")
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $S since its size does not match $(N+1).",
+        )
     end
-    if !isapprox( abs(dot(x,v)), 0.; kwargs...)
-        return DomainError(abs(dot(x,v)),
-            "The vector $(v) is not a tangent vector to $(x) on $(S), since it is not orthogonal in the embedding."
+    if !isapprox(abs(dot(x, v)), 0.0; kwargs...)
+        return DomainError(
+            abs(dot(x, v)),
+            "The vector $(v) is not a tangent vector to $(x) on $(S), since it is not orthogonal in the embedding.",
         )
     end
     return nothing
@@ -118,7 +127,7 @@ injectivity_radius(::Sphere, ::Any...) = π
 Return the injectivity radius for the [`ProjectionRetraction`](@ref) on the
 [`Sphere`](@ref), which is globally $\frac{\pi}{2}$.
 """
-injectivity_radius(::Sphere, ::Any, ::ProjectionRetraction) = π/2
+injectivity_radius(::Sphere, ::Any, ::ProjectionRetraction) = π / 2
 
 @doc doc"""
     inner(S::Sphere, x, w, v)
@@ -129,13 +138,13 @@ metric from the embedding, i.e. $ (v,w)_x = v^\mathrm{T}w $.
 """
 @inline inner(S::Sphere, x, w, v) = dot(w, v)
 
-function get_vector(M::Sphere{N}, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_vector(M::Sphere{N}, x, v, B::ArbitraryOrthonormalBasis) where {N}
     if isapprox(x[1], 1)
         return vcat(0, v)
     else
-        xp1 = x .+ ntuple(i -> ifelse(i == 1, 1, 0), N+1)
+        xp1 = x .+ ntuple(i -> ifelse(i == 1, 1, 0), N + 1)
         v0 = vcat(0, v)
-        return 2*xp1*dot(xp1, v0)/dot(xp1, xp1) - v0
+        return 2 * xp1 * dot(xp1, v0) / dot(xp1, xp1) - v0
     end
 end
 
@@ -151,7 +160,8 @@ since $\langle x,v\rangle = 0$ and when $d_{\mathbb S^2}(x,y) \leq \frac{\pi}{2}
 ````
 """
 inverse_retract(::Sphere, ::Any, ::Any, ::ProjectionInverseRetraction)
-inverse_retract!(::Sphere, v, x, y, ::ProjectionInverseRetraction) = (v .= y./dot(x,y) .- x)
+inverse_retract!(::Sphere, v, x, y, ::ProjectionInverseRetraction) =
+    (v .= y ./ dot(x, y) .- x)
 
 @doc doc"""
     log(M::Sphere, x, y)
@@ -210,7 +220,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 """
 mean(::Sphere, ::Any...)
 mean!(S::Sphere, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(S, y, x, w, GeodesicInterpolationWithinRadius(π/2); kwargs...)
+    mean!(S, y, x, w, GeodesicInterpolationWithinRadius(π / 2); kwargs...)
 
 @doc doc"""
     norm(M::Sphere, x, v)
@@ -265,12 +275,12 @@ Represent the tangent vector `v` at point `x` from a sphere `M` in
 an orthonormal basis by rotating the vector `v` using rotation matrix
 $2\frac{x_p x_p^\mathrm{T}}{x_p^\mathrm{T} x_p} - I$ where $x_p = x + (1, 0, \dots, 0)$.
 """
-function get_coordinates(M::Sphere{N}, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_coordinates(M::Sphere{N}, x, v, B::ArbitraryOrthonormalBasis) where {N}
     if isapprox(x[1], 1)
         return v[2:end]
     else
-        xp1 = x .+ ntuple(i -> ifelse(i == 1, 1, 0), N+1)
-        return (2*xp1*dot(xp1, v)/dot(xp1, xp1) - v)[2:end]
+        xp1 = x .+ ntuple(i -> ifelse(i == 1, 1, 0), N + 1)
+        return (2*xp1*dot(xp1, v)/dot(xp1, xp1)-v)[2:end]
     end
 end
 
@@ -280,7 +290,7 @@ end
 Return the size points on the [`Sphere`](@ref) `M` are represented as, i.e.
 for the `n`-dimensional [`Sphere`](@ref) it is vectors of size `(n+1,)`.
 """
-representation_size(::Sphere{N}) where N = (N+1,)
+representation_size(::Sphere{N}) where {N} = (N + 1,)
 
 @doc doc"""
     retract(M::Sphere, x, y, ::ProjectionRetraction)
@@ -330,8 +340,8 @@ function vector_transport_to!(M::Sphere, vto, x, v, y, ::ParallelTransport)
     vl = norm(M, x, v_xy)
     vto .= v
     if vl > 0
-        factor = 2*dot(v, y)/(norm(x + y)^2)
-        vto .-= factor.*(x .+ y)
+        factor = 2 * dot(v, y) / (norm(x + y)^2)
+        vto .-= factor .* (x .+ y)
     end
     return vto
 end

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -11,6 +11,7 @@ vectors in $\mathbb R^{n+1}$ of unit length
 Generate the $\mathbb S^{n}\subset \mathbb R^{n+1}$
 """
 struct Sphere{N} <: Manifold end
+
 Sphere(n::Int) = Sphere{n}()
 
 function get_basis(M::Sphere{N}, x, B::DiagonalizingOrthonormalBasis) where {N}
@@ -103,6 +104,7 @@ where $\lVert v \rVert_x$ is the [`norm`](@ref norm(::Sphere,x,v)) on the
 [`Sphere`](@ref) `M`.
 """
 exp(::Sphere, ::Any...)
+
 function exp!(M::Sphere, y, x, v)
     θ = norm(M, x, v)
     y .= cos(θ) .* x .+ usinc(θ) .* v
@@ -115,15 +117,13 @@ flat!(M::Sphere, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
     injectivity_radius(M::Sphere[, x])
 
 Return the injectivity radius for the [`Sphere`](@ref) `M`, which is globally $\pi$.
-"""
-injectivity_radius(::Sphere, ::Any...) = π
 
-@doc doc"""
     injectivity_radius(M::Sphere, x, ::ProjectionRetraction)
 
 Return the injectivity radius for the [`ProjectionRetraction`](@ref) on the
 [`Sphere`](@ref), which is globally $\frac{\pi}{2}$.
 """
+injectivity_radius(::Sphere, ::Any...) = π
 injectivity_radius(::Sphere, ::Any, ::ProjectionRetraction) = π / 2
 
 @doc doc"""
@@ -154,6 +154,7 @@ since $\langle x,v\rangle = 0$ and when $d_{\mathbb S^2}(x,y) \leq \frac{\pi}{2}
 ````
 """
 inverse_retract(::Sphere, ::Any, ::Any, ::ProjectionInverseRetraction)
+
 function inverse_retract!(::Sphere, v, x, y, ::ProjectionInverseRetraction)
     return (v .= y ./ dot(x, y) .- x)
 end
@@ -213,6 +214,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolationWithinRadius`](@ref).
 """
 mean(::Sphere, ::Any...)
+
 function mean!(S::Sphere, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return mean!(S, y, x, w, GeodesicInterpolationWithinRadius(π / 2); kwargs...)
 end
@@ -249,6 +251,7 @@ Project the point `x` from the embedding onto the [`Sphere`](@ref) `M`.
 ````
 """
 project_point(::Sphere, ::Any...)
+
 project_point!(S::Sphere, x) = (x ./= norm(x))
 
 @doc doc"""
@@ -261,6 +264,7 @@ Project the point `v` onto the tangent space at `x` on the [`Sphere`](@ref) `M`.
 ````
 """
 project_tangent(::Sphere, ::Any...)
+
 project_tangent!(S::Sphere, w, x, v) = (w .= v .- dot(x, v) .* x)
 
 @doc doc"""
@@ -297,6 +301,7 @@ Compute the retraction that is based on projection, i.e.
 ````
 """
 retract(::Sphere, ::Any, ::Any, ::ProjectionRetraction)
+
 function retract!(M::Sphere, y, x, v, ::ProjectionRetraction)
     y .= x .+ v
     return project_point!(M, y)
@@ -326,6 +331,7 @@ P_{y\gets x}(v) = v - \frac{\langle \log_xy,v\rangle_x}{d^2_{\mathbb S^n}(x,y)}
 ````
 """
 vector_transport_to(::Sphere, ::Any, ::Any, ::Any, ::ParallelTransport)
+
 function vector_transport_to!(M::Sphere, vto, x, v, y, ::ParallelTransport)
     v_xy = log(M, x, y)
     vl = norm(M, x, v_xy)
@@ -344,4 +350,5 @@ Return the zero tangent vector from the tangent space at `x` on the [`Sphere`](@
 which is the zero vector in the embedding.
 """
 zero_tangent_vector(::Sphere, ::Any...)
+
 zero_tangent_vector!(S::Sphere, v, x) = fill!(v, 0)

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -109,9 +109,7 @@ function exp!(M::Sphere, y, x, v)
     return y
 end
 
-function flat!(M::Sphere, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
-    return copyto!(v, w)
-end
+flat!(M::Sphere, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 @doc doc"""
     injectivity_radius(M::Sphere[, x])
@@ -304,9 +302,7 @@ function retract!(M::Sphere, y, x, v, ::ProjectionRetraction)
     return project_point!(M, y)
 end
 
-function sharp!(M::Sphere, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
-    return copyto!(v, w)
-end
+sharp!(M::Sphere, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 """
     uniform_distribution(S::Sphere, x)

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -289,7 +289,7 @@ end
 Return the size points on the [`Sphere`](@ref) `M` are represented as, i.e.
 for the `n`-dimensional [`Sphere`](@ref) it is vectors of size `(n+1,)`.
 """
-representation_size(::Sphere{N}) where {N} = (N + 1,)
+@generated representation_size(::Sphere{N}) where {N} = (N + 1,)
 
 @doc doc"""
     retract(M::Sphere, x, y, ::ProjectionRetraction)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -292,10 +292,10 @@ end
 Returns the representation size of the [`Stiefel`](@ref) `M`=$\operatorname{St}(n,k)$,
 i.e. `(n,k)`, which is the matrix dimensions.
 """
-representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
+@generated representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
 
 @doc doc"""
-    representation_size(M::Stiefel, x)
+    zero_tangent_vector(M::Stiefel, x)
 
 Returns the zero tangent vector from the tangent space at `x` on the [`Stiefel`](@ref)
 `M`=$\operatorname{St}(n,k)$, i.e. an `(n,k)` zero matrix.

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -35,7 +35,7 @@ The manifold is named after
 Generate the (real-valued) Stiefel manifold of $n\times k$ dimensional orthonormal matrices.
 """
 struct Stiefel{n,k,F} <: Manifold end
-Stiefel(n::Int, k::Int,F::AbstractNumbers=ℝ) = Stiefel{n,k,F}()
+Stiefel(n::Int, k::Int, F::AbstractNumbers = ℝ) = Stiefel{n,k,F}()
 @doc doc"""
     check_manifold_point(M::Stiefel, x; kwargs...)
 
@@ -44,23 +44,31 @@ i.e. that it has the right [`AbstractNumbers`](@ref) type and $x^{\mathrm{H}}x$
 is (approximatly) the identity, where $\cdot^{\mathrm{H}}$ is the complex conjugate
 transpose. The settings for approximately can be set with `kwargs...`.
 """
-function check_manifold_point(M::Stiefel{n,k,T},x; kwargs...) where {n,k,T}
-    if (T===ℝ) && !(eltype(x) <: Real)
-        return DomainError(eltype(x),
-            "The matrix $(x) is not a real-valued matrix, so it does noe lie on the Stiefel manifold of dimension ($(n),$(k)).")
+function check_manifold_point(M::Stiefel{n,k,T}, x; kwargs...) where {n,k,T}
+    if (T === ℝ) && !(eltype(x) <: Real)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) is not a real-valued matrix, so it does noe lie on the Stiefel manifold of dimension ($(n),$(k)).",
+        )
     end
-    if (T===ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
-        return DomainError(eltype(x),
-            "The matrix $(x) is neiter real- nor complex-valued matrix, so it does noe lie on the complex Stiefel manifold of dimension ($(n),$(k)).")
+    if (T === ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) is neiter real- nor complex-valued matrix, so it does noe lie on the complex Stiefel manifold of dimension ($(n),$(k)).",
+        )
     end
-    if any( size(x) != representation_size(M) )
-        return DomainError(size(x),
-            "The matrix $(x) is does not lie on the Stiefel manifold of dimension ($(n),$(k)), since its dimensions are wrong.")
+    if any(size(x) != representation_size(M))
+        return DomainError(
+            size(x),
+            "The matrix $(x) is does not lie on the Stiefel manifold of dimension ($(n),$(k)), since its dimensions are wrong.",
+        )
     end
-    c = x'*x
+    c = x' * x
     if !isapprox(c, one(c); kwargs...)
-        return DomainError(norm(c-one(c)),
-            "The point $(x) does not lie on the Stiefel manifold of dimension ($(n),$(k)), because x'x is not the unit matrix.")
+        return DomainError(
+            norm(c - one(c)),
+            "The point $(x) does not lie on the Stiefel manifold of dimension ($(n),$(k)), because x'x is not the unit matrix.",
+        )
     end
 end
 
@@ -72,26 +80,34 @@ Check whether `v` is a valid tangent vector at `x` on the [`Stiefel`](@ref)
 it (approximtly) holds that $x^{\mathrm{H}}v + v^{\mathrm{H}}x = 0$, where
 `kwargs...` is passed to the `isapprox`.
 """
-function check_tangent_vector(M::Stiefel{n,k,T},x,v; kwargs...) where {n,k,T}
-    t = check_manifold_point(M,x)
+function check_tangent_vector(M::Stiefel{n,k,T}, x, v; kwargs...) where {n,k,T}
+    t = check_manifold_point(M, x)
     if (t !== nothing)
         return t
     end
-    if (T===ℝ) && !(eltype(v) <: Real)
-        return DomainError(eltype(v),
-            "The matrix $(v) is not a real-valued matrix, so it can not be a tangent vector to the Stiefel manifold of dimension ($(n),$(k)).")
+    if (T === ℝ) && !(eltype(v) <: Real)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is not a real-valued matrix, so it can not be a tangent vector to the Stiefel manifold of dimension ($(n),$(k)).",
+        )
     end
-    if (T===ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
-        return DomainError(eltype(v),
-            "The matrix $(v) is neiter real- nor complex-valued matrix, so it can not bea tangent vectorto the complex Stiefel manifold of dimension ($(n),$(k)).")
+    if (T === ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is neiter real- nor complex-valued matrix, so it can not bea tangent vectorto the complex Stiefel manifold of dimension ($(n),$(k)).",
+        )
     end
-    if any( size(v) != representation_size(M) )
-        return DomainError(size(v),
-            "The matrix $(v) is does not lie in the tangent space of $(x) on the Stiefel manifold of dimension ($(n),$(k)), since its dimensions are wrong.")
+    if any(size(v) != representation_size(M))
+        return DomainError(
+            size(v),
+            "The matrix $(v) is does not lie in the tangent space of $(x) on the Stiefel manifold of dimension ($(n),$(k)), since its dimensions are wrong.",
+        )
     end
-    if !isapprox(x'*v + v'*x, zeros(k,k); kwargs...)
-        return DomainError(norm(x'*v + v'*x),
-            "The matrix $(v) is does not lie in the tangent space of $(x) on the Stiefel manifold of dimension ($(n),$(k)), since x'v + v'x is not the zero matrix.")
+    if !isapprox(x' * v + v' * x, zeros(k, k); kwargs...)
+        return DomainError(
+            norm(x' * v + v' * x),
+            "The matrix $(v) is does not lie in the tangent space of $(x) on the Stiefel manifold of dimension ($(n),$(k)), since x'v + v'x is not the zero matrix.",
+        )
     end
 end
 
@@ -117,7 +133,10 @@ $0_k$ are the identity matrix and the zero matrix of dimension $k \times k$, res
 """
 exp(::Stiefel, ::Any...)
 function exp!(M::Stiefel{n,k}, y, x, v) where {n,k}
-    y .= [x v] * exp([x'v   -v'*v; one(zeros(eltype(x),k,k))   x'*v]) * [exp(-x'v); zeros(eltype(x),k,k)]
+    y .=
+        [x v] *
+        exp([x'v -v' * v; one(zeros(eltype(x), k, k)) x' * v]) *
+        [exp(-x'v); zeros(eltype(x), k, k)]
     return y
 end
 
@@ -133,7 +152,7 @@ tangent space of `x` on the [`Stiefel`](@ref) manifold `M`. The formula reads
 i.e. the [`EuclideanMetric`](@ref) from the embedding restricted to the tangent
 space. For the complex-valued case this is the Hermitian metric, to be precise.
 """
-inner(::Stiefel, x, v, w) = dot(v,w)
+inner(::Stiefel, x, v, w) = dot(v, w)
 
 @doc doc"""
     inverse_retract(M::Stiefel, x, y, ::PolarInverseRetraction)
@@ -165,11 +184,11 @@ This implementation follows the Lyapunov approach.
 """
 inverse_retract(::Stiefel, ::Any, ::Any, ::PolarInverseRetraction)
 function inverse_retract!(::Stiefel, v, x, y, ::PolarInverseRetraction)
-    A = x'*y
-    H = -2*one(x'*x)
-    B = lyap(A,H)
-    v .= y*B - x
-  return v
+    A = x' * y
+    H = -2 * one(x' * x)
+    B = lyap(A, H)
+    v .= y * B - x
+    return v
 end
 
 @doc doc"""
@@ -187,20 +206,21 @@ in [^KanekoFioriTanaka2013].
 """
 inverse_retract(::Stiefel, ::Any, ::Any, ::QRInverseRetraction)
 function inverse_retract!(::Stiefel{n,k}, v, x, y, ::QRInverseRetraction) where {n,k}
-  A = x'*y
-  R = zeros(typeof(one(eltype(x))*one(eltype(y))),k,k)
-  for i = 1:k
-    b = zeros(i)
-    b[i] = 1
-    b[1:(end-1)] = - transpose(R[1:(i-1), 1:(i-1)]) * A[i, 1:(i-1)]
-    R[1:i, i] = A[1:i, 1:i] \ b
-  end
-  v .= y*R-x
-  return v
+    A = x' * y
+    R = zeros(typeof(one(eltype(x)) * one(eltype(y))), k, k)
+    for i = 1:k
+        b = zeros(i)
+        b[i] = 1
+        b[1:(end-1)] = -transpose(R[1:(i-1), 1:(i-1)]) * A[i, 1:(i-1)]
+        R[1:i, i] = A[1:i, 1:i] \ b
+    end
+    v .= y * R - x
+    return v
 end
 
-isapprox(M::Stiefel, x, v, w; kwargs...) = isapprox(sqrt(inner(M,x,zero_tangent_vector(M,x),v-w)),0;kwargs...)
-isapprox(M::Stiefel, x, y; kwargs...) = isapprox(norm(x-y), 0;kwargs...)
+isapprox(M::Stiefel, x, v, w; kwargs...) =
+    isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+isapprox(M::Stiefel, x, y; kwargs...) = isapprox(norm(x - y), 0; kwargs...)
 
 @doc doc"""
     manifold_dimension(M::Stiefel)
@@ -214,9 +234,9 @@ The dimension is given by
 \dim \mathrm{Stiefel}(n, k, ℍ) &= 4nk - k(2k-1)
 ````
 """
-manifold_dimension(::Stiefel{n,k,ℝ}) where {n,k} = n*k - div(k*(k+1),2)
-manifold_dimension(::Stiefel{n,k,ℂ}) where {n,k} = 2*n*k - k*k
-manifold_dimension(::Stiefel{n,k,ℍ}) where {n,k} = 4*n*k - k*(2k-1)
+manifold_dimension(::Stiefel{n,k,ℝ}) where {n,k} = n * k - div(k * (k + 1), 2)
+manifold_dimension(::Stiefel{n,k,ℂ}) where {n,k} = 2 * n * k - k * k
+manifold_dimension(::Stiefel{n,k,ℍ}) where {n,k} = 4 * n * k - k * (2k - 1)
 
 @doc doc"""
     project_tangent(M, x, v)
@@ -232,7 +252,7 @@ where $\operatorname{Sym}(y)$ is the symmetrization of $y$, e.g. by
 $\operatorname{Sym}(y) = \frac{y^{\mathrm{H}}+y}{2}$.
 """
 project_tangent(::Stiefel, ::Any...)
-project_tangent!(::Stiefel, w, x, v) = ( w.= v - x * Symmetric( x'*v ) )
+project_tangent!(::Stiefel, w, x, v) = (w .= v - x * Symmetric(x' * v))
 
 @doc doc"""
     retract(M, x, v, ::PolarRetraction)
@@ -245,7 +265,7 @@ Compute the SVD-based retraction [`PolarRetraction`](@ref) on the
 """
 retract(::Stiefel, ::Any, ::Any, ::PolarRetraction)
 function retract!(::Stiefel, y, x, v, ::PolarRetraction)
-    s = svd(x+v)
+    s = svd(x + v)
     mul!(y, s.U, s.V')
     return y
 end
@@ -270,9 +290,9 @@ where $\operatorname{sgn}(x) = \begin{cases}
 """
 retract(::Stiefel, ::Any, ::Any, ::QRRetraction)
 function retract!(::Stiefel, y, x, v, ::QRRetraction)
-    qrfac = qr(x+v)
+    qrfac = qr(x + v)
     d = diag(qrfac.R)
-    D = Diagonal( sign.( sign.(d .+ 0.5)) )
+    D = Diagonal(sign.(sign.(d .+ 0.5)))
     y .= Matrix(qrfac.Q) * D
     return y
 end
@@ -283,7 +303,7 @@ end
 Returns the representation size of the [`Stiefel`](@ref) `M`=$\operatorname{St}(n,k)$,
 i.e. `(n,k)`, which is the matrix dimensions.
 """
-representation_size(::Stiefel{n,k}) where {n,k} = (n,k)
+representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
 
 @doc doc"""
     representation_size(M::Stiefel, x)
@@ -292,4 +312,4 @@ Returns the zero tangent vector from the tangent space at `x` on the [`Stiefel`]
 `M`=$\operatorname{St}(n,k)$, i.e. an `(n,k)` zero matrix.
 """
 zero_tangent_vector(::Stiefel, ::Any...)
-zero_tangent_vector!(::Stiefel,v,x) = fill!(v,0)
+zero_tangent_vector!(::Stiefel, v, x) = fill!(v, 0)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -133,10 +133,11 @@ $0_k$ are the identity matrix and the zero matrix of dimension $k \times k$, res
 """
 exp(::Stiefel, ::Any...)
 function exp!(M::Stiefel{n,k}, y, x, v) where {n,k}
-    y .=
+    y .= (
         [x v] *
         exp([x'v -v' * v; one(zeros(eltype(x), k, k)) x' * v]) *
         [exp(-x'v); zeros(eltype(x), k, k)]
+    )
     return y
 end
 
@@ -218,8 +219,9 @@ function inverse_retract!(::Stiefel{n,k}, v, x, y, ::QRInverseRetraction) where 
     return v
 end
 
-isapprox(M::Stiefel, x, v, w; kwargs...) =
-    isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+function isapprox(M::Stiefel, x, v, w; kwargs...)
+    return isapprox(sqrt(inner(M, x, zero_tangent_vector(M, x), v - w)), 0; kwargs...)
+end
 isapprox(M::Stiefel, x, y; kwargs...) = isapprox(norm(x - y), 0; kwargs...)
 
 @doc doc"""

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra: diag, qr, tr, svd, mul!, zeros, lyap
-
 @doc doc"""
     Stiefel{n,k,T} <: Manifold
 

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -69,9 +69,8 @@ and its values have to be from the correct [`AbstractNumbers`](@ref).
 The tolerance for the symmetry of `x` and `v` can be set using `kwargs...`.
 """
 function check_tangent_vector(M::SymmetricMatrices{n,F}, x, v; kwargs...) where {n,F}
-    if (check_manifold_point(M, x; kwargs...) !== nothing)
-        return check_manifold_point(M, x; kwargs...)
-    end
+    t = check_manifold_point(M, x; kwargs...)
+    t === nothing || return t
     if (F === ℝ) && !(eltype(v) <: Real)
         return DomainError(
             eltype(v),
@@ -118,11 +117,7 @@ Compute the exponential map eminating from `x` in tangent direction `v` on the
 ````
 """
 exp(::SymmetricMatrices, ::Any...)
-function exp!(M::SymmetricMatrices, y, x, v)
-    y .= x .+ v
-    return y
-end
-
+exp!(M::SymmetricMatrices, y, x, v) = (y .= x .+ v)
 
 @doc doc"""
     flat(M::SymmetricMatrices, x, w::FVector{TangentSpaceType})
@@ -246,10 +241,7 @@ reads
 ````
 """
 log(::SymmetricMatrices, ::Any...)
-function log!(M::SymmetricMatrices, v, x, y)
-    v .= y .- x
-    return v
-end
+log!(M::SymmetricMatrices, v, x, y) = (v .= y .- x)
 
 @doc doc"""
 manifold_dimension(M::SymmetricMatrices{n,𝔽})
@@ -349,8 +341,7 @@ P_{y\gets x}(v) = v.
 """
 vector_transport_to(::SymmetricMatrices, ::Any...)
 function vector_transport_to!(M::SymmetricMatrices, vto, x, v, y, ::ParallelTransport)
-    copyto!(vto, v)
-    return vto
+    return copyto!(vto, v)
 end
 
 @doc doc"""
@@ -360,7 +351,4 @@ Return the zero tangent vector for the tangent space at `x` on the
 [`SymmetricMatrices`](@ref) `M`, i.e. the zero matrix.
 """
 zero_tangent_vector(::SymmetricMatrices, ::Any...)
-function zero_tangent_vector!(M::SymmetricMatrices, v, x)
-    fill!(v, 0)
-    return v
-end
+zero_tangent_vector!(M::SymmetricMatrices, v, x) = fill!(v, 0)

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -134,8 +134,7 @@ function flat!(
     x,
     w::FVector{TangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 function get_coordinates(
@@ -323,8 +322,7 @@ function sharp!(
     x,
     w::FVector{CotangentSpaceType},
 )
-    copyto!(v.data, w.data)
-    return v
+    return copyto!(v, w)
 end
 
 @doc doc"""

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -20,6 +20,7 @@ Though it is slighty redundant, usually the matrices are safed as $n\times n$ ar
 Generate the manifold of $n\times n$ symmetric metrices.
 """
 struct SymmetricMatrices{n,F} <: Manifold end
+
 SymmetricMatrices(n::Int, F::AbstractNumbers = ℝ) = SymmetricMatrices{n,F}()
 
 @doc doc"""
@@ -101,13 +102,13 @@ end
 @doc doc"""
     distance(M::SymmetricMatrices, x, y)
 
-Computeby using the inherited metric, i.e. taking the Frobenius-norm of the difference.
-
+Compute distance using the inherited metric, i.e. taking the Frobenius-norm of the
+difference.
 """
 distance(M::SymmetricMatrices, x, y) = norm(x - y)
 
 @doc doc"""
-    exp!(M::SymmetricMatrices, y, x, v)
+    exp(M::SymmetricMatrices, x, v)
 
 Compute the exponential map eminating from `x` in tangent direction `v` on the
 [`SymmetricMatrices`](@ref) `M`, which reads
@@ -117,6 +118,7 @@ Compute the exponential map eminating from `x` in tangent direction `v` on the
 ````
 """
 exp(::SymmetricMatrices, ::Any...)
+
 exp!(M::SymmetricMatrices, y, x, v) = (y .= x .+ v)
 
 @doc doc"""
@@ -128,6 +130,7 @@ Compute the [`flat`](@ref flat(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 flat(::SymmetricMatrices, ::Any...)
+
 flat!(M::SymmetricMatrices, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_coordinates(
@@ -148,7 +151,6 @@ function get_coordinates(
     end
     return vout
 end
-
 function get_coordinates(
     M::SymmetricMatrices{N,ℂ},
     x,
@@ -189,7 +191,6 @@ function get_vector(
     end
     return vout
 end
-
 function get_vector(
     M::SymmetricMatrices{N,ℂ},
     x,
@@ -233,6 +234,7 @@ reads
 ````
 """
 log(::SymmetricMatrices, ::Any...)
+
 log!(M::SymmetricMatrices, v, x, y) = (v .= y .- x)
 
 @doc doc"""
@@ -275,6 +277,7 @@ Projects `x` from the embedding onto the [`SymmetricMatrices`](@ref) `M`, i.e.
 where $\cdot^{\mathrm{H}}$ denotes the hermitian, i.e. complex conjugate transposed.
 """
 project_point(::SymmetricMatrices, ::Any...)
+
 project_point!(M::SymmetricMatrices, x) = (x .= (x + transpose(x)) ./ 2)
 
 @doc doc"""
@@ -289,6 +292,7 @@ Project the matrix `v` onto the tangent space at `x` on the [`SymmetricMatrices`
 where $\cdot^{\mathrm{H}}$ denotes the hermitian, i.e. complex conjugate transposed.
 """
 project_tangent(::SymmetricMatrices, ::Any...)
+
 project_tangent!(M::SymmetricMatrices, w, x, v) = (w .= (v .+ transpose(v)) ./ 2)
 
 @doc doc"""
@@ -299,7 +303,6 @@ for the $n\times n$ it's `(n,n)`.
 """
 representation_size(::SymmetricMatrices{N}) where {N} = (N, N)
 
-
 @doc doc"""
     sharp(M::SymmetricMatrices, x, w::FVector{CotangentSpaceType})
 
@@ -309,6 +312,7 @@ Compute the [`sharp`](@ref sharp(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 sharp(::SymmetricMatrices, ::Any...)
+
 sharp!(M::SymmetricMatrices, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 @doc doc"""
@@ -324,6 +328,7 @@ P_{y\gets x}(v) = v.
 ````
 """
 vector_transport_to(::SymmetricMatrices, ::Any...)
+
 function vector_transport_to!(M::SymmetricMatrices, vto, x, v, y, ::ParallelTransport)
     return copyto!(vto, v)
 end
@@ -335,4 +340,5 @@ Return the zero tangent vector for the tangent space at `x` on the
 [`SymmetricMatrices`](@ref) `M`, i.e. the zero matrix.
 """
 zero_tangent_vector(::SymmetricMatrices, ::Any...)
+
 zero_tangent_vector!(M::SymmetricMatrices, v, x) = fill!(v, 0)

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -128,14 +128,7 @@ Compute the [`flat`](@ref flat(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 flat(::SymmetricMatrices, ::Any...)
-function flat!(
-    M::SymmetricMatrices,
-    v::FVector{CotangentSpaceType},
-    x,
-    w::FVector{TangentSpaceType},
-)
-    return copyto!(v, w)
-end
+flat!(M::SymmetricMatrices, v::CoTFVector, x, w::TFVector) = copyto!(v, w)
 
 function get_coordinates(
     M::SymmetricMatrices{N,ℝ},
@@ -316,14 +309,7 @@ Compute the [`sharp`](@ref sharp(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 sharp(::SymmetricMatrices, ::Any...)
-function sharp!(
-    M::SymmetricMatrices,
-    v::FVector{TangentSpaceType},
-    x,
-    w::FVector{CotangentSpaceType},
-)
-    return copyto!(v, w)
-end
+sharp!(M::SymmetricMatrices, v::TFVector, x, w::CoTFVector) = copyto!(v, w)
 
 @doc doc"""
     vector_transport_to(M::SymmetricMatrices, x, v, y, ::ParallelTransport)

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -20,7 +20,7 @@ Though it is slighty redundant, usually the matrices are safed as $n\times n$ ar
 Generate the manifold of $n\times n$ symmetric metrices.
 """
 struct SymmetricMatrices{n,F} <: Manifold end
-SymmetricMatrices(n::Int,F::AbstractNumbers=ℝ) = SymmetricMatrices{n,F}()
+SymmetricMatrices(n::Int, F::AbstractNumbers = ℝ) = SymmetricMatrices{n,F}()
 
 @doc doc"""
     check_manifold_point(M::SymmetricMatrices{n,F}, x; kwargs...)
@@ -31,18 +31,30 @@ whether `x` is a symmetric matrix of size `(n,n)` with values from the correspon
 
 The tolerance for the symmetry of `x` can be set using `kwargs...`.
 """
-function check_manifold_point(M::SymmetricMatrices{n,F},x; kwargs...) where {n,F}
-    if (F===ℝ) && !(eltype(x) <: Real)
-        return DomainError(eltype(x),"The matrix $(x) does not lie on $M, since its values are not real.")
+function check_manifold_point(M::SymmetricMatrices{n,F}, x; kwargs...) where {n,F}
+    if (F === ℝ) && !(eltype(x) <: Real)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) does not lie on $M, since its values are not real.",
+        )
     end
-    if (F===ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
-        return DomainError(eltype(x),"The matrix $(x) does not lie on $M, since its values are not complex.")
+    if (F === ℂ) && !(eltype(x) <: Real) && !(eltype(x) <: Complex)
+        return DomainError(
+            eltype(x),
+            "The matrix $(x) does not lie on $M, since its values are not complex.",
+        )
     end
-    if size(x) != (n,n)
-        return DomainError(size(x),"The point $(x) does not lie on $M since its size ($(size(x))) does not match the representation size ($(representation_size(M))).")
+    if size(x) != (n, n)
+        return DomainError(
+            size(x),
+            "The point $(x) does not lie on $M since its size ($(size(x))) does not match the representation size ($(representation_size(M))).",
+        )
     end
-    if !isapprox(norm(x-transpose(x)),0.; kwargs...)
-        return DomainError(norm(x-transpose(x)), "The point $(x) does not lie on $M, since it is not symmetric.")
+    if !isapprox(norm(x - transpose(x)), 0.0; kwargs...)
+        return DomainError(
+            norm(x - transpose(x)),
+            "The point $(x) does not lie on $M, since it is not symmetric.",
+        )
     end
     return nothing
 end
@@ -57,22 +69,32 @@ and its values have to be from the correct [`AbstractNumbers`](@ref).
 The tolerance for the symmetry of `x` and `v` can be set using `kwargs...`.
 """
 function check_tangent_vector(M::SymmetricMatrices{n,F}, x, v; kwargs...) where {n,F}
-    if (check_manifold_point(M, x;kwargs...) !== nothing)
-        return check_manifold_point(M,x;kwargs...)
+    if (check_manifold_point(M, x; kwargs...) !== nothing)
+        return check_manifold_point(M, x; kwargs...)
     end
-    if (F===ℝ) && !(eltype(v) <: Real)
-        return DomainError(eltype(v),"The matrix $(v) is not a tangent to a point on $M, since its values are not real.")
+    if (F === ℝ) && !(eltype(v) <: Real)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is not a tangent to a point on $M, since its values are not real.",
+        )
     end
-    if (F===ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
-        return DomainError(eltype(v),"The matrix $(v) is not a tangent to a point on $M, since its values are not complex.")
+    if (F === ℂ) && !(eltype(v) <: Real) && !(eltype(v) <: Complex)
+        return DomainError(
+            eltype(v),
+            "The matrix $(v) is not a tangent to a point on $M, since its values are not complex.",
+        )
     end
-    if size(v) != (n,n)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $(M) since its size ($(size(v))) does not match the representation size ($(representation_size(M))).")
+    if size(v) != (n, n)
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $(M) since its size ($(size(v))) does not match the representation size ($(representation_size(M))).",
+        )
     end
-    if !isapprox(norm(v-transpose(v)),0.; kwargs...)
-        return DomainError(norm(v-transpose(v)),
-            "The vector $(v) is not a tangent vector to $(x) on $(M), since it is not symmetric.")
+    if !isapprox(norm(v - transpose(v)), 0.0; kwargs...)
+        return DomainError(
+            norm(v - transpose(v)),
+            "The vector $(v) is not a tangent vector to $(x) on $(M), since it is not symmetric.",
+        )
     end
     return nothing
 end
@@ -83,7 +105,7 @@ end
 Computeby using the inherited metric, i.e. taking the Frobenius-norm of the difference.
 
 """
-distance(M::SymmetricMatrices, x, y) = norm(x-y)
+distance(M::SymmetricMatrices, x, y) = norm(x - y)
 
 @doc doc"""
     exp!(M::SymmetricMatrices, y, x, v)
@@ -111,66 +133,91 @@ Compute the [`flat`](@ref flat(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 flat(::SymmetricMatrices, ::Any...)
-function flat!(M::SymmetricMatrices, v::FVector{CotangentSpaceType}, x, w::FVector{TangentSpaceType})
+function flat!(
+    M::SymmetricMatrices,
+    v::FVector{CotangentSpaceType},
+    x,
+    w::FVector{TangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
 
-function get_coordinates(M::SymmetricMatrices{N, ℝ}, x, v, B::ArbitraryOrthonormalBasis{ℝ}) where N
+function get_coordinates(
+    M::SymmetricMatrices{N,ℝ},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis{ℝ},
+) where {N}
     dim = manifold_dimension(M)
     vout = similar(v, dim)
     @assert size(v) == (N, N)
-    @assert dim == div(N*(N+1), 2)
+    @assert dim == div(N * (N + 1), 2)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, sqrt(2))
-        @inbounds vout[k] = v[i,j]*scale
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, sqrt(2))
+        @inbounds vout[k] = v[i, j] * scale
         k += 1
     end
     return vout
 end
 
-function get_coordinates(M::SymmetricMatrices{N, ℂ}, x, v, B::ArbitraryOrthonormalBasis{ℝ}) where N
+function get_coordinates(
+    M::SymmetricMatrices{N,ℂ},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis{ℝ},
+) where {N}
     dim = manifold_dimension(M)
     vout = similar(v, dim)
     @assert size(v) == (N, N)
-    @assert dim == N*(N+1)
+    @assert dim == N * (N + 1)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, sqrt(2))
-        @inbounds vout[k] = real(v[i,j]) * scale
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, sqrt(2))
+        @inbounds vout[k] = real(v[i, j]) * scale
         k += 1
-        @inbounds vout[k] = imag(v[i,j]) * scale
+        @inbounds vout[k] = imag(v[i, j]) * scale
         k += 1
     end
     return vout
 end
 
-function get_vector(M::SymmetricMatrices{N, ℝ}, x, v, B::ArbitraryOrthonormalBasis{ℝ}) where N
+function get_vector(
+    M::SymmetricMatrices{N,ℝ},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis{ℝ},
+) where {N}
     dim = manifold_dimension(M)
     vout = similar_result(M, get_vector, x)
-    @assert size(v) == (div(N*(N+1), 2),)
+    @assert size(v) == (div(N * (N + 1), 2),)
     @assert size(vout) == (N, N)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, 1/sqrt(2))
-        @inbounds vout[i,j] = v[k]*scale
-        @inbounds vout[j,i] = v[k]*scale
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, 1 / sqrt(2))
+        @inbounds vout[i, j] = v[k] * scale
+        @inbounds vout[j, i] = v[k] * scale
         k += 1
     end
     return vout
 end
 
-function get_vector(M::SymmetricMatrices{N, ℂ}, x, v, B::ArbitraryOrthonormalBasis{ℝ}) where N
+function get_vector(
+    M::SymmetricMatrices{N,ℂ},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis{ℝ},
+) where {N}
     dim = manifold_dimension(M)
     vout = similar_result(M, get_vector, x, x .* 1im)
-    @assert size(v) == (N*(N+1),)
+    @assert size(v) == (N * (N + 1),)
     @assert size(vout) == (N, N)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, 1/sqrt(2))
-        @inbounds vout[i,j] = Complex(v[k], v[k+1])*scale
-        @inbounds vout[j,i] = vout[i,j]
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, 1 / sqrt(2))
+        @inbounds vout[i, j] = Complex(v[k], v[k+1]) * scale
+        @inbounds vout[j, i] = vout[i, j]
         k += 2
     end
     return vout
@@ -200,7 +247,7 @@ reads
 """
 log(::SymmetricMatrices, ::Any...)
 function log!(M::SymmetricMatrices, v, x, y)
-    v .= y.-x
+    v .= y .- x
     return v
 end
 
@@ -217,7 +264,7 @@ Return the dimension of the [`SymmetricMatrices`](@ref) matrix `M` over the numb
 where $\dim_ℝ 𝔽$ is the [`real_dimension`](@ref) of `𝔽`.
 """
 function manifold_dimension(::SymmetricMatrices{N,𝔽}) where {N,𝔽}
-    return div(N*(N+1),2)*real_dimension(𝔽)
+    return div(N * (N + 1), 2) * real_dimension(𝔽)
 end
 
 @doc doc"""
@@ -244,7 +291,7 @@ Projects `x` from the embedding onto the [`SymmetricMatrices`](@ref) `M`, i.e.
 where $\cdot^{\mathrm{H}}$ denotes the hermitian, i.e. complex conjugate transposed.
 """
 project_point(::SymmetricMatrices, ::Any...)
-project_point!(M::SymmetricMatrices, x) = (x .= (x + transpose(x))./2)
+project_point!(M::SymmetricMatrices, x) = (x .= (x + transpose(x)) ./ 2)
 
 @doc doc"""
     project_tangent(M::SymmetricMatrices, x, v)
@@ -258,7 +305,7 @@ Project the matrix `v` onto the tangent space at `x` on the [`SymmetricMatrices`
 where $\cdot^{\mathrm{H}}$ denotes the hermitian, i.e. complex conjugate transposed.
 """
 project_tangent(::SymmetricMatrices, ::Any...)
-project_tangent!(M::SymmetricMatrices, w, x, v) = (w .= (v .+ transpose(v))./2 )
+project_tangent!(M::SymmetricMatrices, w, x, v) = (w .= (v .+ transpose(v)) ./ 2)
 
 @doc doc"""
     representation_size(M::SymmetricMatrices)
@@ -266,7 +313,7 @@ project_tangent!(M::SymmetricMatrices, w, x, v) = (w .= (v .+ transpose(v))./2 )
 Returns the size points on the [`SymmetricMatrices`](@ref) `M` are represented as, i.e.
 for the $n\times n$ it's `(n,n)`.
 """
-representation_size(::SymmetricMatrices{N}) where {N} = (N,N)
+representation_size(::SymmetricMatrices{N}) where {N} = (N, N)
 
 
 @doc doc"""
@@ -278,7 +325,12 @@ Compute the [`sharp`](@ref sharp(M::Manifold, x, w::FVector)) isomorphism of the
 Since `M` is already a vector space over $\mathbb R$, this returns just the vector `w`.
 """
 sharp(::SymmetricMatrices, ::Any...)
-function sharp!(M::SymmetricMatrices, v::FVector{TangentSpaceType}, x, w::FVector{CotangentSpaceType})
+function sharp!(
+    M::SymmetricMatrices,
+    v::FVector{TangentSpaceType},
+    x,
+    w::FVector{CotangentSpaceType},
+)
     copyto!(v.data, w.data)
     return v
 end
@@ -297,7 +349,7 @@ P_{y\gets x}(v) = v.
 """
 vector_transport_to(::SymmetricMatrices, ::Any...)
 function vector_transport_to!(M::SymmetricMatrices, vto, x, v, y, ::ParallelTransport)
-    copyto!(vto,v)
+    copyto!(vto, v)
     return vto
 end
 
@@ -307,7 +359,7 @@ end
 Return the zero tangent vector for the tangent space at `x` on the
 [`SymmetricMatrices`](@ref) `M`, i.e. the zero matrix.
 """
-zero_tangent_vector(::SymmetricMatrices,::Any...)
+zero_tangent_vector(::SymmetricMatrices, ::Any...)
 function zero_tangent_vector!(M::SymmetricMatrices, v, x)
     fill!(v, 0)
     return v

--- a/src/manifolds/Symmetric.jl
+++ b/src/manifolds/Symmetric.jl
@@ -301,7 +301,7 @@ project_tangent!(M::SymmetricMatrices, w, x, v) = (w .= (v .+ transpose(v)) ./ 2
 Returns the size points on the [`SymmetricMatrices`](@ref) `M` are represented as, i.e.
 for the $n\times n$ it's `(n,n)`.
 """
-representation_size(::SymmetricMatrices{N}) where {N} = (N, N)
+@generated representation_size(::SymmetricMatrices{N}) where {N} = (N, N)
 
 @doc doc"""
     sharp(M::SymmetricMatrices, x, w::FVector{CotangentSpaceType})

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -1,6 +1,3 @@
-using LinearAlgebra:
-    diag, eigen, eigvals, eigvecs, Symmetric, Diagonal, tr, cholesky, LowerTriangular
-using ManifoldsBase: ParallelTransport
 @doc doc"""
     SymmetricPositiveDefinite{N} <: Manifold
 

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -174,7 +174,6 @@ Return the size of an array representing an element on the
 [`SymmetricPositiveDefinite`](@ref) manifold `M`, i.e. $n\times n$, the size of such a
 symmetric positive definite matrix on $\mathcal M = \mathcal P(n)$.
 """
-representation_size(::SymmetricPositiveDefinite{N}) where {N} = (N, N)
 function representation_size(
     ::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
 ) where {N}
@@ -185,6 +184,7 @@ function representation_size(
 ) where {N}
     return (N, N)
 end
+@generated representation_size(::SymmetricPositiveDefinite{N}) where {N} = (N, N)
 
 @doc doc"""
     zero_tangent_vector(M::SymmetricPositiveDefinite,x)

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -55,11 +55,13 @@ function check_manifold_point(M::SymmetricPositiveDefinite{N}, x; kwargs...) whe
     end
     return nothing
 end
-check_manifold_point(
+function check_manifold_point(
     M::MetricManifold{SymmetricPositiveDefinite{N},T},
     x;
     kwargs...,
-) where {N,T<:Metric} = check_manifold_point(M.manifold, x; kwargs...)
+) where {N,T<:Metric}
+    return check_manifold_point(M.manifold, x; kwargs...)
+end
 
 """
     check_tangent_vector(M::SymmetricPositiveDefinite, x, v; kwargs... )
@@ -107,14 +109,18 @@ Since `M` is a Hadamard manifold with respect to the [`LinearAffineMetric`](@ref
 [`LogCholeskyMetric`](@ref), the injectivity radius is globally $\infty$.
 """
 injectivity_radius(M::SymmetricPositiveDefinite{N}, args...) where {N} = Inf
-injectivity_radius(
+function injectivity_radius(
     M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
     args...,
-) where {N} = Inf
-injectivity_radius(
+) where {N}
+    return Inf
+end
+function injectivity_radius(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
     args...,
-) where {N} = Inf
+) where {N}
+    return Inf
+end
 
 @doc doc"""
     manifold_dimension(M::SymmetricPositiveDefinite)
@@ -125,14 +131,19 @@ returns the dimension of
 \dim \mathcal P(n) = \frac{n(n+1)}{2}
 ````
 """
-@generated manifold_dimension(M::SymmetricPositiveDefinite{N}) where {N} =
-    div(N * (N + 1), 2)
-@generated manifold_dimension(
+@generated function manifold_dimension(M::SymmetricPositiveDefinite{N}) where {N}
+    return div(N * (N + 1), 2)
+end
+@generated function manifold_dimension(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
-) where {N} = div(N * (N + 1), 2)
-@generated manifold_dimension(
+) where {N}
+    return div(N * (N + 1), 2)
+end
+@generated function manifold_dimension(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
-) where {N} = div(N * (N + 1), 2)
+) where {N}
+    return div(N * (N + 1), 2)
+end
 
 """
     mean(
@@ -147,8 +158,15 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolation`](@ref).
 """
 mean(::SymmetricPositiveDefinite, ::Any)
-mean!(M::SymmetricPositiveDefinite, y, x::AbstractVector, w::AbstractVector; kwargs...) =
-    mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
+function mean!(
+    M::SymmetricPositiveDefinite,
+    y,
+    x::AbstractVector,
+    w::AbstractVector;
+    kwargs...,
+)
+    return mean!(M, y, x, w, GeodesicInterpolation(); kwargs...)
+end
 
 @doc doc"""
     representation_size(M::SymmetricPositiveDefinite)
@@ -158,12 +176,16 @@ Return the size of an array representing an element on the
 symmetric positive definite matrix on $\mathcal M = \mathcal P(n)$.
 """
 representation_size(::SymmetricPositiveDefinite{N}) where {N} = (N, N)
-representation_size(
+function representation_size(
     ::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
-) where {N} = (N, N)
-representation_size(
+) where {N}
+    return (N, N)
+end
+function representation_size(
     ::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
-) where {N} = (N, N)
+) where {N}
+    return (N, N)
+end
 
 @doc doc"""
     zero_tangent_vector(M::SymmetricPositiveDefinite,x)
@@ -172,13 +194,17 @@ returns the zero tangent vector in the tangent space of the symmetric positive
 definite matrix `x` on the [`SymmetricPositiveDefinite`](@ref) manifold `M`.
 """
 zero_tangent_vector(M::SymmetricPositiveDefinite, x) = zero(x)
-zero_tangent_vector(
+function zero_tangent_vector(
     M::MetricManifold{SymmetricPositiveDefinite{N},T},
     x,
-) where {N,T<:Metric} = zero(x)
+) where {N,T<:Metric}
+    return zero(x)
+end
 zero_tangent_vector!(M::SymmetricPositiveDefinite{N}, v, x) where {N} = fill!(v, 0)
-zero_tangent_vector!(
+function zero_tangent_vector!(
     M::MetricManifold{SymmetricPositiveDefinite{N},T},
     v,
     x,
-) where {N,T<:Metric} = fill!(v, 0)
+) where {N,T<:Metric}
+    return fill!(v, 0)
+end

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -53,13 +53,6 @@ function check_manifold_point(M::SymmetricPositiveDefinite{N}, x; kwargs...) whe
     end
     return nothing
 end
-function check_manifold_point(
-    M::MetricManifold{SymmetricPositiveDefinite{N},T},
-    x;
-    kwargs...,
-) where {N,T<:Metric}
-    return check_manifold_point(M.manifold, x; kwargs...)
-end
 
 """
     check_tangent_vector(M::SymmetricPositiveDefinite, x, v; kwargs... )
@@ -86,14 +79,6 @@ function check_tangent_vector(M::SymmetricPositiveDefinite{N}, x, v; kwargs...) 
     end
     return nothing
 end
-function check_tangent_vector(
-    M::MetricManifold{SymmetricPositiveDefinite{N},T},
-    x,
-    v;
-    kwargs...,
-) where {N,T<:Metric}
-    return check_tangent_vector(base_manifold(M), x, v; kwargs...)
-end
 
 is_default_metric(::SymmetricPositiveDefinite, ::LinearAffineMetric) = Val(true)
 
@@ -107,18 +92,6 @@ Since `M` is a Hadamard manifold with respect to the [`LinearAffineMetric`](@ref
 [`LogCholeskyMetric`](@ref), the injectivity radius is globally $\infty$.
 """
 injectivity_radius(M::SymmetricPositiveDefinite{N}, args...) where {N} = Inf
-function injectivity_radius(
-    M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
-    args...,
-) where {N}
-    return Inf
-end
-function injectivity_radius(
-    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
-    args...,
-) where {N}
-    return Inf
-end
 
 @doc doc"""
     manifold_dimension(M::SymmetricPositiveDefinite)
@@ -130,16 +103,6 @@ returns the dimension of
 ````
 """
 @generated function manifold_dimension(M::SymmetricPositiveDefinite{N}) where {N}
-    return div(N * (N + 1), 2)
-end
-@generated function manifold_dimension(
-    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
-) where {N}
-    return div(N * (N + 1), 2)
-end
-@generated function manifold_dimension(
-    M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
-) where {N}
     return div(N * (N + 1), 2)
 end
 
@@ -174,16 +137,6 @@ Return the size of an array representing an element on the
 [`SymmetricPositiveDefinite`](@ref) manifold `M`, i.e. $n\times n$, the size of such a
 symmetric positive definite matrix on $\mathcal M = \mathcal P(n)$.
 """
-function representation_size(
-    ::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
-) where {N}
-    return (N, N)
-end
-function representation_size(
-    ::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
-) where {N}
-    return (N, N)
-end
 @generated representation_size(::SymmetricPositiveDefinite{N}) where {N} = (N, N)
 
 @doc doc"""
@@ -201,10 +154,3 @@ function zero_tangent_vector(
 end
 
 zero_tangent_vector!(M::SymmetricPositiveDefinite{N}, v, x) where {N} = fill!(v, 0)
-function zero_tangent_vector!(
-    M::MetricManifold{SymmetricPositiveDefinite{N},T},
-    v,
-    x,
-) where {N,T<:Metric}
-    return fill!(v, 0)
-end

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -18,6 +18,7 @@ x \in \mathbb R^{n\times n} :
 generates the manifold $\mathcal P(n) \subset \mathbb R^{n\times n}$
 """
 struct SymmetricPositiveDefinite{N} <: Manifold end
+
 SymmetricPositiveDefinite(n::Int) = SymmetricPositiveDefinite{n}()
 
 include("SymmetricPositiveDefiniteLinearAffine.jl")
@@ -155,6 +156,7 @@ Compute the Riemannian [`mean`](@ref mean(M::Manifold, args...)) of `x` using
 [`GeodesicInterpolation`](@ref).
 """
 mean(::SymmetricPositiveDefinite, ::Any)
+
 function mean!(
     M::SymmetricPositiveDefinite,
     y,
@@ -197,6 +199,7 @@ function zero_tangent_vector(
 ) where {N,T<:Metric}
     return zero(x)
 end
+
 zero_tangent_vector!(M::SymmetricPositiveDefinite{N}, v, x) where {N} = fill!(v, 0)
 function zero_tangent_vector!(
     M::MetricManifold{SymmetricPositiveDefinite{N},T},

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -1,4 +1,5 @@
-using LinearAlgebra: diag, eigen, eigvals, eigvecs, Symmetric, Diagonal, tr, cholesky, LowerTriangular
+using LinearAlgebra:
+    diag, eigen, eigvals, eigvecs, Symmetric, Diagonal, tr, cholesky, LowerTriangular
 using ManifoldsBase: ParallelTransport
 @doc doc"""
     SymmetricPositiveDefinite{N} <: Manifold
@@ -33,19 +34,32 @@ checks, whether `x` is a valid point on the [`SymmetricPositiveDefinite`](@ref) 
 of size `(N,N)`, symmetric and positive definite.
 The tolerance for the second to last test can be set using the `kwargs...`.
 """
-function check_manifold_point(M::SymmetricPositiveDefinite{N},x; kwargs...) where N
+function check_manifold_point(M::SymmetricPositiveDefinite{N}, x; kwargs...) where {N}
     if size(x) != representation_size(M)
-        return DomainError(size(x),"The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).")
+        return DomainError(
+            size(x),
+            "The point $(x) does not lie on $(M), since its size is not $(representation_size(M)).",
+        )
     end
-    if !isapprox(norm(x-transpose(x)), 0.; kwargs...)
-        return DomainError(norm(x), "The point $(x) does not lie on $(M) since its not a symmetric matrix:")
+    if !isapprox(norm(x - transpose(x)), 0.0; kwargs...)
+        return DomainError(
+            norm(x),
+            "The point $(x) does not lie on $(M) since its not a symmetric matrix:",
+        )
     end
-    if ! all( eigvals(x) .> 0 )
-        return DomainError(norm(x), "The point $x does not lie on $(M) since its not a positive definite matrix.")
+    if !all(eigvals(x) .> 0)
+        return DomainError(
+            norm(x),
+            "The point $x does not lie on $(M) since its not a positive definite matrix.",
+        )
     end
     return nothing
 end
-check_manifold_point(M::MetricManifold{SymmetricPositiveDefinite{N},T},x; kwargs...) where {N, T<:Metric} = check_manifold_point(M.manifold, x; kwargs...)
+check_manifold_point(
+    M::MetricManifold{SymmetricPositiveDefinite{N},T},
+    x;
+    kwargs...,
+) where {N,T<:Metric} = check_manifold_point(M.manifold, x; kwargs...)
 
 """
     check_tangent_vector(M::SymmetricPositiveDefinite, x, v; kwargs... )
@@ -55,24 +69,33 @@ i.e. atfer [`check_manifold_point`](@ref)`(M,x)`, `v` has to be of same dimensio
 and a symmetric matrix, i.e. this stores tangent vetors as elements of the corresponding
 Lie group. The tolerance for the last test can be set using the `kwargs...`.
 """
-function check_tangent_vector(M::SymmetricPositiveDefinite{N},x,v; kwargs...) where N
-    mpe = check_manifold_point(M,x)
+function check_tangent_vector(M::SymmetricPositiveDefinite{N}, x, v; kwargs...) where {N}
+    mpe = check_manifold_point(M, x)
     mpe === nothing || return mpe
     if size(v) != representation_size(M)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $(M) since its size does not match $(representation_size(M)).")
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $(M) since its size does not match $(representation_size(M)).",
+        )
     end
-    if !isapprox(norm(v-transpose(v)), 0.; kwargs...)
-        return DomainError(size(v),
-            "The vector $(v) is not a tangent to a point on $(M) (represented as an element of the Lie algebra) since its not symmetric.")
+    if !isapprox(norm(v - transpose(v)), 0.0; kwargs...)
+        return DomainError(
+            size(v),
+            "The vector $(v) is not a tangent to a point on $(M) (represented as an element of the Lie algebra) since its not symmetric.",
+        )
     end
     return nothing
 end
-function check_tangent_vector(M::MetricManifold{SymmetricPositiveDefinite{N},T},x,v; kwargs...) where {N, T <: Metric}
-    return check_tangent_vector(base_manifold(M), x, v;kwargs...)
+function check_tangent_vector(
+    M::MetricManifold{SymmetricPositiveDefinite{N},T},
+    x,
+    v;
+    kwargs...,
+) where {N,T<:Metric}
+    return check_tangent_vector(base_manifold(M), x, v; kwargs...)
 end
 
-is_default_metric(::SymmetricPositiveDefinite,::LinearAffineMetric) = Val(true)
+is_default_metric(::SymmetricPositiveDefinite, ::LinearAffineMetric) = Val(true)
 
 @doc doc"""
     injectivity_radius(M::SymmetricPositiveDefinite[, x])
@@ -83,9 +106,15 @@ Return the injectivity radius of the [`SymmetricPositiveDefinite`](@ref).
 Since `M` is a Hadamard manifold with respect to the [`LinearAffineMetric`](@ref) and the
 [`LogCholeskyMetric`](@ref), the injectivity radius is globally $\infty$.
 """
-injectivity_radius(M::SymmetricPositiveDefinite{N}, args...) where N = Inf
-injectivity_radius(M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric}, args...) where N = Inf
-injectivity_radius(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}, args...) where N = Inf
+injectivity_radius(M::SymmetricPositiveDefinite{N}, args...) where {N} = Inf
+injectivity_radius(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
+    args...,
+) where {N} = Inf
+injectivity_radius(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    args...,
+) where {N} = Inf
 
 @doc doc"""
     manifold_dimension(M::SymmetricPositiveDefinite)
@@ -96,9 +125,14 @@ returns the dimension of
 \dim \mathcal P(n) = \frac{n(n+1)}{2}
 ````
 """
-@generated manifold_dimension(M::SymmetricPositiveDefinite{N}) where {N} = div(N*(N+1), 2)
-@generated manifold_dimension(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}) where {N} = div(N*(N+1), 2)
-@generated manifold_dimension(M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric}) where {N} = div(N*(N+1), 2)
+@generated manifold_dimension(M::SymmetricPositiveDefinite{N}) where {N} =
+    div(N * (N + 1), 2)
+@generated manifold_dimension(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+) where {N} = div(N * (N + 1), 2)
+@generated manifold_dimension(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
+) where {N} = div(N * (N + 1), 2)
 
 """
     mean(
@@ -123,9 +157,13 @@ Return the size of an array representing an element on the
 [`SymmetricPositiveDefinite`](@ref) manifold `M`, i.e. $n\times n$, the size of such a
 symmetric positive definite matrix on $\mathcal M = \mathcal P(n)$.
 """
-representation_size(::SymmetricPositiveDefinite{N}) where N = (N,N)
-representation_size(::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}) where N = (N,N)
-representation_size(::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric}) where N = (N,N)
+representation_size(::SymmetricPositiveDefinite{N}) where {N} = (N, N)
+representation_size(
+    ::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+) where {N} = (N, N)
+representation_size(
+    ::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
+) where {N} = (N, N)
 
 @doc doc"""
     zero_tangent_vector(M::SymmetricPositiveDefinite,x)
@@ -134,6 +172,13 @@ returns the zero tangent vector in the tangent space of the symmetric positive
 definite matrix `x` on the [`SymmetricPositiveDefinite`](@ref) manifold `M`.
 """
 zero_tangent_vector(M::SymmetricPositiveDefinite, x) = zero(x)
-zero_tangent_vector(M::MetricManifold{SymmetricPositiveDefinite{N},T}, x) where {N, T<:Metric} = zero(x)
-zero_tangent_vector!(M::SymmetricPositiveDefinite{N}, v, x) where N = fill!(v, 0)
-zero_tangent_vector!(M::MetricManifold{SymmetricPositiveDefinite{N},T}, v, x) where {N, T<:Metric} = fill!(v, 0)
+zero_tangent_vector(
+    M::MetricManifold{SymmetricPositiveDefinite{N},T},
+    x,
+) where {N,T<:Metric} = zero(x)
+zero_tangent_vector!(M::SymmetricPositiveDefinite{N}, v, x) where {N} = fill!(v, 0)
+zero_tangent_vector!(
+    M::MetricManifold{SymmetricPositiveDefinite{N},T},
+    v,
+    x,
+) where {N,T<:Metric} = fill!(v, 0)

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -21,10 +21,6 @@ struct SymmetricPositiveDefinite{N} <: Manifold end
 
 SymmetricPositiveDefinite(n::Int) = SymmetricPositiveDefinite{n}()
 
-include("SymmetricPositiveDefiniteLinearAffine.jl")
-include("SymmetricPositiveDefiniteLogCholesky.jl")
-include("SymmetricPositiveDefiniteLogEuclidean.jl")
-
 @doc doc"""
     check_manifold_point(M::SymmetricPositiveDefinite, x; kwargs...)
 
@@ -79,8 +75,6 @@ function check_tangent_vector(M::SymmetricPositiveDefinite{N}, x, v; kwargs...) 
     end
     return nothing
 end
-
-is_default_metric(::SymmetricPositiveDefinite, ::LinearAffineMetric) = Val(true)
 
 @doc doc"""
     injectivity_radius(M::SymmetricPositiveDefinite[, x])

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -40,6 +40,7 @@ Compute the exponential map from `x` with tangent vector `v` on the
 where $\operatorname{Exp}$ denotes to the matrix exponential.
 """
 exp(::SymmetricPositiveDefinite, ::Any...)
+
 function exp!(M::SymmetricPositiveDefinite{N}, y, x, v) where {N}
     e = eigen(Symmetric(x))
     U = e.vectors
@@ -178,6 +179,7 @@ x^{\frac{1}{2}}\operatorname{Log}(x^{-\frac{1}{2}}yx^{-\frac{1}{2}})x^{\frac{1}{
 where $\operatorname{Log}$ denotes to the matrix logarithm.
 """
 log(::SymmetricPositiveDefinite, ::Any...)
+
 function log!(M::SymmetricPositiveDefinite{N}, v, x, y) where {N}
     e = eigen(Symmetric(x))
     U = e.vectors
@@ -218,6 +220,7 @@ and `log` the logarithmic map on [`SymmetricPositiveDefinite`](@ref)
 (again with respect to the metric mentioned).
 """
 vector_transport_to(::SymmetricPositiveDefinite, ::Any, ::Any, ::Any, ::ParallelTransport)
+
 function vector_transport_to!(
     M::SymmetricPositiveDefinite{N},
     vto,

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -6,6 +6,8 @@ matrix logarithms and exponentials, which yields a linear and affine metric.
 """
 struct LinearAffineMetric <: RiemannianMetric end
 
+is_default_metric(::SymmetricPositiveDefinite, ::LinearAffineMetric) = Val(true)
+
 @doc doc"""
     distance(M::SymmetricPositiveDefinite, x, y)
     distance(M::MetricManifold{SymmetricPositiveDefinite,LinearAffineMetric})

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -20,9 +20,9 @@ d_{\mathcal P(n)}(x,y)
 where $\operatorname{Log}$ denotes the matrix logarithm and
 $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
 """
-function distance(M::SymmetricPositiveDefinite{N},x,y) where N
-    s = real.( eigvals( x,y ) )
-    return any(s .<= eps() ) ? 0 : sqrt(  sum( abs.(log.(s)).^2 )  )
+function distance(M::SymmetricPositiveDefinite{N}, x, y) where {N}
+    s = real.(eigvals(x, y))
+    return any(s .<= eps()) ? 0 : sqrt(sum(abs.(log.(s)) .^ 2))
 end
 
 @doc doc"""
@@ -40,20 +40,20 @@ Compute the exponential map from `x` with tangent vector `v` on the
 where $\operatorname{Exp}$ denotes to the matrix exponential.
 """
 exp(::SymmetricPositiveDefinite, ::Any...)
-function exp!(M::SymmetricPositiveDefinite{N}, y, x, v) where N
+function exp!(M::SymmetricPositiveDefinite{N}, y, x, v) where {N}
     e = eigen(Symmetric(x))
     U = e.vectors
     S = e.values
-    Ssqrt = Diagonal( sqrt.(S) )
-    SsqrtInv = Diagonal( 1 ./ sqrt.(S) )
-    xSqrt = Symmetric(U*Ssqrt*transpose(U))
-    xSqrtInv = Symmetric(U*SsqrtInv*transpose(U))
+    Ssqrt = Diagonal(sqrt.(S))
+    SsqrtInv = Diagonal(1 ./ sqrt.(S))
+    xSqrt = Symmetric(U * Ssqrt * transpose(U))
+    xSqrtInv = Symmetric(U * SsqrtInv * transpose(U))
     T = Symmetric(xSqrtInv * v * xSqrtInv)
-    eig1 = eigen( T ) # numerical stabilization
-    Se = Diagonal( exp.(eig1.values) )
+    eig1 = eigen(T) # numerical stabilization
+    Se = Diagonal(exp.(eig1.values))
     Ue = eig1.vectors
-    xue = xSqrt*Ue
-    copyto!(y, xue*Se*transpose(xue) )
+    xue = xSqrt * Ue
+    copyto!(y, xue * Se * transpose(xue))
     return y
 end
 
@@ -67,49 +67,80 @@ Return a orthonormal basis `Ξ` as a vector of tangent vectors (of length
 [`LinearAffineMetric`](@ref) that diagonalizes the curvature tensor $R(u,v)w$
 with eigenvalues `κ` and where the direction `B.v` has curvature `0`.
 """
-function get_basis(M::SymmetricPositiveDefinite{N}, x, B::DiagonalizingOrthonormalBasis) where N
+function get_basis(
+    M::SymmetricPositiveDefinite{N},
+    x,
+    B::DiagonalizingOrthonormalBasis,
+) where {N}
     xSqrt = sqrt(x)
     eigv = eigen(B.v)
     V = eigv.vectors
-    Ξ = [ (i==j ? 1/2 : 1/sqrt(2))*( V[:,i] * transpose(V[:,j])  +  V[:,j] * transpose(V[:,i]) )
-        for i=1:N for j= i:N
+    Ξ = [
+        (i == j ? 1 / 2 :
+             1 / sqrt(2)) * (V[:, i] * transpose(V[:, j]) + V[:, j] * transpose(V[:, i]))
+        for i = 1:N
+        for j = i:N
     ]
     λ = eigv.values
-    κ = [ -1/4 * (λ[i]-λ[j])^2 for i=1:N for j= i:N ]
+    κ = [-1 / 4 * (λ[i] - λ[j])^2 for i = 1:N for j = i:N]
     return PrecomputedDiagonalizingOrthonormalBasis(Ξ, κ)
 end
-get_basis(M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric}, x, B::DiagonalizingOrthonormalBasis) where {N} = get_basis(base_manifold(M), x, B)
+get_basis(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
+    x,
+    B::DiagonalizingOrthonormalBasis,
+) where {N} = get_basis(base_manifold(M), x, B)
 
-function get_coordinates(M::SymmetricPositiveDefinite{N}, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_coordinates(
+    M::SymmetricPositiveDefinite{N},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis,
+) where {N}
     dim = manifold_dimension(M)
     vout = similar(v, dim)
     @assert size(v) == (N, N)
-    @assert dim == div(N*(N+1), 2)
+    @assert dim == div(N * (N + 1), 2)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, sqrt(2))
-        @inbounds vout[k] = v[i,j]*scale
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, sqrt(2))
+        @inbounds vout[k] = v[i, j] * scale
         k += 1
     end
     return vout
 end
-get_coordinates(M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric}, x, v, B::ArbitraryOrthonormalBasis) where {N} = get_coordinates(base_manifold(M), x, v, B)
+get_coordinates(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis,
+) where {N} = get_coordinates(base_manifold(M), x, v, B)
 
-function get_vector(M::SymmetricPositiveDefinite{N}, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_vector(
+    M::SymmetricPositiveDefinite{N},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis,
+) where {N}
     dim = manifold_dimension(M)
     vout = similar_result(M, get_vector, x)
-    @assert size(v) == (div(N*(N+1), 2),)
+    @assert size(v) == (div(N * (N + 1), 2),)
     @assert size(vout) == (N, N)
     k = 1
-    for i in 1:N, j in i:N
-        scale = ifelse(i==j, 1, 1/sqrt(2))
-        @inbounds vout[i,j] = v[k]*scale
-        @inbounds vout[j,i] = v[k]*scale
+    for i = 1:N, j = i:N
+        scale = ifelse(i == j, 1, 1 / sqrt(2))
+        @inbounds vout[i, j] = v[k] * scale
+        @inbounds vout[j, i] = v[k] * scale
         k += 1
     end
     return vout
 end
-get_vector(M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric}, x, v, B::ArbitraryOrthonormalBasis) where {N} = get_vector(base_manifold(M), x, v, B)
+get_vector(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
+    x,
+    v,
+    B::ArbitraryOrthonormalBasis,
+) where {N} = get_vector(base_manifold(M), x, v, B)
 
 @doc doc"""
     inner(M::SymmetricPositiveDefinite, x, v, w)
@@ -142,19 +173,19 @@ x^{\frac{1}{2}}\operatorname{Log}(x^{-\frac{1}{2}}yx^{-\frac{1}{2}})x^{\frac{1}{
 where $\operatorname{Log}$ denotes to the matrix logarithm.
 """
 log(::SymmetricPositiveDefinite, ::Any...)
-function log!(M::SymmetricPositiveDefinite{N}, v, x, y) where N
+function log!(M::SymmetricPositiveDefinite{N}, v, x, y) where {N}
     e = eigen(Symmetric(x))
     U = e.vectors
     S = e.values
-    Ssqrt = Diagonal( sqrt.(S) )
-    SsqrtInv = Diagonal( 1 ./ sqrt.(S) )
-    xSqrt = Symmetric( U*Ssqrt*transpose(U) )
-    xSqrtInv = Symmetric( U*SsqrtInv*transpose(U) )
-    T = Symmetric( xSqrtInv * y * xSqrtInv )
-    e2 = eigen( T )
-    Se = Diagonal( log.(max.(e2.values,eps()) ) )
-    xue = xSqrt*e2.vectors
-    mul!(v,xue,Se*transpose(xue))
+    Ssqrt = Diagonal(sqrt.(S))
+    SsqrtInv = Diagonal(1 ./ sqrt.(S))
+    xSqrt = Symmetric(U * Ssqrt * transpose(U))
+    xSqrtInv = Symmetric(U * SsqrtInv * transpose(U))
+    T = Symmetric(xSqrtInv * y * xSqrtInv)
+    e2 = eigen(T)
+    Se = Diagonal(log.(max.(e2.values, eps())))
+    xue = xSqrt * e2.vectors
+    mul!(v, xue, Se * transpose(xue))
     return v
 end
 
@@ -183,8 +214,15 @@ and `log` the logarithmic map on [`SymmetricPositiveDefinite`](@ref)
 (again with respect to the metric mentioned).
 """
 vector_transport_to(::SymmetricPositiveDefinite, ::Any, ::Any, ::Any, ::ParallelTransport)
-function vector_transport_to!(M::SymmetricPositiveDefinite{N}, vto, x, v, y, ::ParallelTransport) where N
-    if distance(M,x,y)<2*eps(eltype(x))
+function vector_transport_to!(
+    M::SymmetricPositiveDefinite{N},
+    vto,
+    x,
+    v,
+    y,
+    ::ParallelTransport,
+) where {N}
+    if distance(M, x, y) < 2 * eps(eltype(x))
         copyto!(vto, v)
         return vto
     end
@@ -192,21 +230,21 @@ function vector_transport_to!(M::SymmetricPositiveDefinite{N}, vto, x, v, y, ::P
     U = e.vectors
     S = e.values
     Ssqrt = sqrt.(S)
-    SsqrtInv = Diagonal( 1 ./ Ssqrt )
-    Ssqrt = Diagonal( Ssqrt )
-    xSqrt = Symmetric(U*Ssqrt*transpose(U))
-    xSqrtInv = Symmetric(U*SsqrtInv*transpose(U))
+    SsqrtInv = Diagonal(1 ./ Ssqrt)
+    Ssqrt = Diagonal(Ssqrt)
+    xSqrt = Symmetric(U * Ssqrt * transpose(U))
+    xSqrtInv = Symmetric(U * SsqrtInv * transpose(U))
     tv = Symmetric(xSqrtInv * v * xSqrtInv)
     ty = Symmetric(xSqrtInv * y * xSqrtInv)
-    e2 = eigen( ty )
-    Se = Diagonal( log.(e2.values) )
+    e2 = eigen(ty)
+    Se = Diagonal(log.(e2.values))
     Ue = e2.vectors
-    ty2 = Symmetric(Ue*Se*transpose(Ue))
-    e3 = eigen( ty2 )
-    Sf = Diagonal( exp.(e3.values) )
+    ty2 = Symmetric(Ue * Se * transpose(Ue))
+    e3 = eigen(ty2)
+    Sf = Diagonal(exp.(e3.values))
     Uf = e3.vectors
-    xue = xSqrt*Uf*Sf*transpose(Uf)
-    vtp = Symmetric(xue*tv*transpose(xue))
+    xue = xSqrt * Uf * Sf * transpose(Uf)
+    vtp = Symmetric(xue * tv * transpose(xue))
     copyto!(vto, vtp)
     return vto
 end

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -85,11 +85,13 @@ function get_basis(
     κ = [-1 / 4 * (λ[i] - λ[j])^2 for i = 1:N for j = i:N]
     return PrecomputedDiagonalizingOrthonormalBasis(Ξ, κ)
 end
-get_basis(
+function get_basis(
     M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
     x,
     B::DiagonalizingOrthonormalBasis,
-) where {N} = get_basis(base_manifold(M), x, B)
+) where {N}
+    return get_basis(base_manifold(M), x, B)
+end
 
 function get_coordinates(
     M::SymmetricPositiveDefinite{N},
@@ -109,12 +111,14 @@ function get_coordinates(
     end
     return vout
 end
-get_coordinates(
+function get_coordinates(
     M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
     x,
     v,
     B::ArbitraryOrthonormalBasis,
-) where {N} = get_coordinates(base_manifold(M), x, v, B)
+) where {N}
+    return get_coordinates(base_manifold(M), x, v, B)
+end
 
 function get_vector(
     M::SymmetricPositiveDefinite{N},
@@ -135,12 +139,14 @@ function get_vector(
     end
     return vout
 end
-get_vector(
+function get_vector(
     M::MetricManifold{SymmetricPositiveDefinite{N},LinearAffineMetric},
     x,
     v,
     B::ArbitraryOrthonormalBasis,
-) where {N} = get_vector(base_manifold(M), x, v, B)
+) where {N}
+    return get_vector(base_manifold(M), x, v, B)
+end
 
 @doc doc"""
     inner(M::SymmetricPositiveDefinite, x, v, w)

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -53,8 +53,7 @@ function exp!(M::SymmetricPositiveDefinite{N}, y, x, v) where {N}
     Se = Diagonal(exp.(eig1.values))
     Ue = eig1.vectors
     xue = xSqrt * Ue
-    copyto!(y, xue * Se * transpose(xue))
-    return y
+    return copyto!(y, xue * Se * transpose(xue))
 end
 
 @doc doc"""
@@ -191,8 +190,7 @@ function log!(M::SymmetricPositiveDefinite{N}, v, x, y) where {N}
     e2 = eigen(T)
     Se = Diagonal(log.(max.(e2.values, eps())))
     xue = xSqrt * e2.vectors
-    mul!(v, xue, Se * transpose(xue))
-    return v
+    return mul!(v, xue, Se * transpose(xue))
 end
 
 @doc doc"""
@@ -228,10 +226,7 @@ function vector_transport_to!(
     y,
     ::ParallelTransport,
 ) where {N}
-    if distance(M, x, y) < 2 * eps(eltype(x))
-        copyto!(vto, v)
-        return vto
-    end
+    distance(M, x, y) < 2 * eps(eltype(x)) && copyto!(vto, v)
     e = eigen(Symmetric(x))
     U = e.vectors
     S = e.values
@@ -251,6 +246,5 @@ function vector_transport_to!(
     Uf = e3.vectors
     xue = xSqrt * Uf * Sf * transpose(Uf)
     vtp = Symmetric(xue * tv * transpose(xue))
-    copyto!(vto, vtp)
-    return vto
+    return copyto!(vto, vtp)
 end

--- a/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
@@ -67,8 +67,7 @@ function exp!(
 ) where {N}
     (l, w) = spd_to_cholesky(x, v)
     z = exp(CholeskySpace{N}(), l, w)
-    y .= z * z'
-    return y
+    return copyto!(y, z * z')
 end
 
 @doc doc"""
@@ -120,8 +119,7 @@ function log!(
     l = cholesky(x).L
     k = cholesky(y).L
     log!(CholeskySpace{N}(), v, l, k)
-    tangent_cholesky_to_tangent_spd!(l, v)
-    return v
+    return tangent_cholesky_to_tangent_spd!(l, v)
 end
 
 @doc doc"""
@@ -157,6 +155,5 @@ function vector_transport_to!(
     k = cholesky(y).L
     (l, w) = spd_to_cholesky(x, v)
     vector_transport_to!(CholeskySpace{N}(), vto, l, w, k, ParallelTransport())
-    tangent_cholesky_to_tangent_spd!(k, vto)
-    return vto
+    return tangent_cholesky_to_tangent_spd!(k, vto)
 end

--- a/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
@@ -9,9 +9,13 @@ introduced by [^Lin2019].
     > Cholesky Decomposition", arXiv: [1908.09326](https://arxiv.org/abs/1908.09326).
 """
 struct LogCholeskyMetric <: RiemannianMetric end
+
 cholesky_to_spd(l, w) = (l * l', w * l' + l * w')
+
 tangent_cholesky_to_tangent_spd!(l, w) = (w .= w * l' + l * w')
+
 spd_to_cholesky(x, v) = spd_to_cholesky(x, cholesky(x).L, v)
+
 function spd_to_cholesky(x, l, v)
     w = inv(l) * v * inv(transpose(l))
     # strictly lower triangular plus half diagonal
@@ -59,6 +63,7 @@ and $(\cdot)_\frac{1}{2}$
 denotes the lower triangular matrix with the diagonal multiplied by $\frac{1}{2}$.
 """
 exp(::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
+
 function exp!(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
     y,
@@ -110,6 +115,7 @@ where $l$ is the colesky factor of $x$ and $w=\log_lk$ for $k$ the cholesky fact
 of $y$ and the just mentioned logarithmic map is the one on [`CholeskySpace`](@ref).
 """
 log(::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
+
 function log!(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
     v,
@@ -123,7 +129,13 @@ function log!(
 end
 
 @doc doc"""
-    vector_transport_to(M::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, x, v, y, ::ParallelTransport)
+    vector_transport_to(
+        M::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric},
+        x,
+        v,
+        y,
+        ::ParallelTransport,
+    )
 
 Parallely transport the tangent vector `v` at `x` along the geodesic to `y` with respect to
 the [`SymmetricPositiveDefinite`](@ref) manifold `M` and [`LogCholeskyMetric`](@ref).
@@ -144,6 +156,7 @@ vector_transport_to(
     ::Any,
     ::ParallelTransport,
 )
+
 function vector_transport_to!(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
     vto,

--- a/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
@@ -9,13 +9,13 @@ introduced by [^Lin2019].
     > Cholesky Decomposition", arXiv: [1908.09326](https://arxiv.org/abs/1908.09326).
 """
 struct LogCholeskyMetric <: RiemannianMetric end
-cholesky_to_spd(l,w) = (l*l', w*l' + l*w')
-tangent_cholesky_to_tangent_spd!(l,w) = (w .= w*l' + l*w')
-spd_to_cholesky(x,v) = spd_to_cholesky(x,cholesky(x).L,v)
-function spd_to_cholesky(x,l,v)
-    w = inv(l)*v*inv(transpose(l))
+cholesky_to_spd(l, w) = (l * l', w * l' + l * w')
+tangent_cholesky_to_tangent_spd!(l, w) = (w .= w * l' + l * w')
+spd_to_cholesky(x, v) = spd_to_cholesky(x, cholesky(x).L, v)
+function spd_to_cholesky(x, l, v)
+    w = inv(l) * v * inv(transpose(l))
     # strictly lower triangular plus half diagonal
-    return (l, l*(LowerTriangular(w) - Diagonal(w)/2) )
+    return (l, l * (LowerTriangular(w) - Diagonal(w) / 2))
 end
 
 @doc doc"""
@@ -35,7 +35,11 @@ where $l$ and $k$ are the cholesky factors of $x$ and $y$, respectively,
 $\lfloor\cdot\rfloor$ denbotes the strictly lower triangular matrix of its argument,
 and $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the Frobenius norm.
 """
-distance(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},x,y) where N = distance(CholeskySpace{N}(), cholesky(x).L, cholesky(y).L)
+distance(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    x,
+    y,
+) where {N} = distance(CholeskySpace{N}(), cholesky(x).L, cholesky(y).L)
 
 @doc doc"""
     exp(M::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, x, v)
@@ -53,10 +57,15 @@ and $(\cdot)_\frac{1}{2}$
 denotes the lower triangular matrix with the diagonal multiplied by $\frac{1}{2}$.
 """
 exp(::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
-function exp!(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}, y, x, v) where {N}
-    (l,w) = spd_to_cholesky(x,v)
-    z = exp(CholeskySpace{N}(),l,w)
-    y .= z*z'
+function exp!(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    y,
+    x,
+    v,
+) where {N}
+    (l, w) = spd_to_cholesky(x, v)
+    z = exp(CholeskySpace{N}(), l, w)
+    y .= z * z'
     return y
 end
 
@@ -76,9 +85,14 @@ $l$ is the cholesky factor of $x$,
 $p_l(w) = l (l^{-1}wl^{-\mathrm{T}})_{\frac{1}{2}}$, and $(\cdot)_\frac{1}{2}$
 denotes the lower triangular matrix with the diagonal multiplied by $\frac{1}{2}$
 """
-function inner(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},x,v,w) where N
-    (l,vl) = spd_to_cholesky(x,v)
-    (l,wl) = spd_to_cholesky(x,l,w)
+function inner(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    x,
+    v,
+    w,
+) where {N}
+    (l, vl) = spd_to_cholesky(x, v)
+    (l, wl) = spd_to_cholesky(x, l, w)
     return inner(CholeskySpace{N}(), l, vl, wl)
 end
 
@@ -95,7 +109,12 @@ where $l$ is the colesky factor of $x$ and $w=\log_lk$ for $k$ the cholesky fact
 of $y$ and the just mentioned logarithmic map is the one on [`CholeskySpace`](@ref).
 """
 log(::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
-function log!(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}, v, x, y) where N
+function log!(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    v,
+    x,
+    y,
+) where {N}
     l = cholesky(x).L
     k = cholesky(y).L
     log!(CholeskySpace{N}(), v, l, k)
@@ -118,11 +137,24 @@ transport on [`CholeskySpace`](@ref) from $l$ to $k$. The formula hear reads
     \mathcal P_{y\gets x}(v) = ku^{\mathrm{T}} + uk^{\mathrm{T}}.
 ````
 """
-vector_transport_to(::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any, ::Any, ::Any, ::ParallelTransport)
-function vector_transport_to!(M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric}, vto, x, v, y, ::ParallelTransport) where N
+vector_transport_to(
+    ::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric},
+    ::Any,
+    ::Any,
+    ::Any,
+    ::ParallelTransport,
+)
+function vector_transport_to!(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
+    vto,
+    x,
+    v,
+    y,
+    ::ParallelTransport,
+) where {N}
     k = cholesky(y).L
-    (l,w) = spd_to_cholesky(x,v)
-    vector_transport_to!(CholeskySpace{N}(),vto,l , w , k, ParallelTransport())
-    tangent_cholesky_to_tangent_spd!(k,vto)
+    (l, w) = spd_to_cholesky(x, v)
+    vector_transport_to!(CholeskySpace{N}(), vto, l, w, k, ParallelTransport())
+    tangent_cholesky_to_tangent_spd!(k, vto)
     return vto
 end

--- a/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
@@ -35,11 +35,13 @@ where $l$ and $k$ are the cholesky factors of $x$ and $y$, respectively,
 $\lfloor\cdot\rfloor$ denbotes the strictly lower triangular matrix of its argument,
 and $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the Frobenius norm.
 """
-distance(
+function distance(
     M::MetricManifold{SymmetricPositiveDefinite{N},LogCholeskyMetric},
     x,
     y,
-) where {N} = distance(CholeskySpace{N}(), cholesky(x).L, cholesky(y).L)
+) where {N}
+    return distance(CholeskySpace{N}(), cholesky(x).L, cholesky(y).L)
+end
 
 @doc doc"""
     exp(M::MetricManifold{SymmetricPositiveDefinite,LogCholeskyMetric}, x, v)

--- a/src/manifolds/SymmetricPositiveDefiniteLogEuclidean.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogEuclidean.jl
@@ -20,6 +20,10 @@ The formula reads
 where $\operatorname{Log}$ denotes the matrix logarithm and
 $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
 """
-function distance(M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},x,y) where N
+function distance(
+    M::MetricManifold{SymmetricPositiveDefinite{N},LogEuclideanMetric},
+    x,
+    y,
+) where {N}
     return norm(log(Symmetric(x)) - log(Symmetric(y)))
 end

--- a/src/manifolds/Torus.jl
+++ b/src/manifolds/Torus.jl
@@ -9,29 +9,43 @@ The Circle is stored internally within `manifold`, such that all functions of
 struct Torus{N} <: AbstractPowerManifold{Circle}
     manifold::Circle
 end
+
 Torus(n::Int) = Torus{n}(Circle())
+
 @doc doc"""
     check_manifold_point(M::Torus{n},x)
 
 check whether `x` is a valid point on the [`GraphManifold`](@ref)
 """
-check_manifold_point(::Torus,::Any)
+check_manifold_point(::Torus, ::Any)
 function check_manifold_point(M::Torus{N}, x; kwargs...) where {N}
     if length(x) != N
-        return DomainError(length(x), "The number of elements in `x` ($(length(x))) does not match the dimension of the torus ($(N)).")
+        return DomainError(
+            length(x),
+            "The number of elements in `x` ($(length(x))) does not match the dimension of the torus ($(N)).",
+        )
     end
-    return check_manifold_point(PowerManifold(M.manifold,N), x; kwargs...)
+    return check_manifold_point(PowerManifold(M.manifold, N), x; kwargs...)
 end
 
 function check_tangent_vector(M::Torus{N}, x, v; kwargs...) where {N}
     if length(x) != N
-        return DomainError(length(x), "The number of elements in `x` ($(length(x))) does not match the dimension of the torus ($(N)).")
+        return DomainError(
+            length(x),
+            "The number of elements in `x` ($(length(x))) does not match the dimension of the torus ($(N)).",
+        )
     end
     if length(v) != N
-        return DomainError(length(v), "The number of elements in `v` ($(length(v))) does not match the dimension of the torus ($(N)).")
+        return DomainError(
+            length(v),
+            "The number of elements in `v` ($(length(v))) does not match the dimension of the torus ($(N)).",
+        )
     end
-    return check_tangent_vector(PowerManifold(M.manifold,N), x, v; kwargs...)
+    return check_tangent_vector(PowerManifold(M.manifold, N), x, v; kwargs...)
 end
+
 get_iterator(M::Torus{N}) where {N} = 1:N
-representation_size(M::Torus{N}) where {N} = (N,)
-manifold_dimension(M::Torus{N}) where {N} = N
+
+@generated manifold_dimension(::Torus{N}) where {N} = N
+
+@generated representation_size(::Torus{N}) where {N} = (N,)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -82,9 +82,7 @@ end
 Return an object of type [`VectorSpaceAtPoint`](@ref) representing tangent
 space at `x`.
 """
-function TangentSpaceAtPoint(M::Manifold, x)
-    return VectorSpaceAtPoint(TangentBundleFibers(M), x)
-end
+TangentSpaceAtPoint(M::Manifold, x) = VectorSpaceAtPoint(TangentBundleFibers(M), x)
 
 """
     CotangentSpaceAtPoint(M::Manifold, x)
@@ -92,9 +90,7 @@ end
 Return an object of type [`VectorSpaceAtPoint`](@ref) representing cotangent
 space at `x`.
 """
-function CotangentSpaceAtPoint(M::Manifold, x)
-    return VectorSpaceAtPoint(CotangentBundleFibers(M), x)
-end
+CotangentSpaceAtPoint(M::Manifold, x) = VectorSpaceAtPoint(CotangentBundleFibers(M), x)
 
 """
     VectorBundle(M::Manifold, type::VectorSpaceType)
@@ -237,8 +233,7 @@ $\flat \colon T\mathcal M \to T^{*}\mathcal M$
 """
 function flat(M::Manifold, x, w::FVector)
     v = similar_result(M, flat, w, x)
-    flat!(M, v, x, w)
-    return v
+    return flat!(M, v, x, w)
 end
 function flat!(M::Manifold, v::FVector, x, w::FVector)
     error(
@@ -361,9 +356,7 @@ function inner(B::VectorBundleFibers, x, v, w)
         "vectors of types $(typeof(v)) and $(typeof(w)).",
     )
 end
-function inner(B::VectorBundleFibers{<:TangentSpaceType}, x, v, w)
-    return inner(B.M, x, v, w)
-end
+inner(B::VectorBundleFibers{<:TangentSpaceType}, x, v, w) = inner(B.M, x, v, w)
 function inner(B::VectorBundleFibers{<:CotangentSpaceType}, x, v, w)
     return inner(
         B.M,
@@ -510,12 +503,10 @@ Project vector `w` from the vector space of type `B.VS` at point `x`.
 """
 function project_vector(B::VectorBundleFibers, x, w)
     v = similar_result(B, project_vector, x, w)
-    project_vector!(B, v, x, w)
-    return v
+    return project_vector!(B, v, x, w)
 end
 function project_vector!(B::VectorBundleFibers{<:TangentSpaceType}, v, x, w)
-    project_tangent!(B.M, v, x, w)
-    return v
+    return project_tangent!(B.M, v, x, w)
 end
 function project_vector!(B::VectorBundleFibers, v, x, w)
     error("project_vector! not implemented for vector space family of type $(typeof(B)), output vector of type $(typeof(v)) and input vector at point $(typeof(x)) with type of w $(typeof(w)).")
@@ -523,9 +514,7 @@ end
 
 Base.@propagate_inbounds setindex!(x::FVector, val, i) = setindex!(x.data, val, i)
 
-function representation_size(B::VectorBundleFibers{<:TCoTSpaceType})
-    representation_size(B.M)
-end
+representation_size(B::VectorBundleFibers{<:TCoTSpaceType}) = representation_size(B.M)
 function representation_size(B::VectorBundle)
     len_manifold = prod(representation_size(B.M))
     len_vs = prod(representation_size(B.VS))
@@ -544,8 +533,7 @@ $\sharp \colon T^{*}\mathcal M \to T\mathcal M$
 """
 function sharp(M::Manifold, x, w::FVector)
     v = similar_result(M, sharp, w, x)
-    sharp!(M, v, x, w)
-    return v
+    return sharp!(M, v, x, w)
 end
 
 function sharp!(M::Manifold, v::FVector, x, w::FVector)
@@ -620,8 +608,7 @@ function zero_vector!(B::VectorBundleFibers, v, x)
 end
 
 function zero_vector!(B::VectorBundleFibers{<:TangentSpaceType}, v, x)
-    zero_tangent_vector!(B.M, v, x)
-    return v
+    return zero_tangent_vector!(B.M, v, x)
 end
 
 """
@@ -632,8 +619,7 @@ from manifold `B.M`.
 """
 function zero_vector(B::VectorBundleFibers, x)
     v = similar_result(B, zero_vector, x)
-    zero_vector!(B, v, x)
-    return v
+    return zero_vector!(B, v, x)
 end
 @doc doc"""
     zero_tangent_vector!(B::VectorBundle, v, x)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -264,18 +264,10 @@ function get_basis(M::TangentBundleFibers, x, B::DiagonalizingOrthonormalBasis)
 end
 
 function get_coordinates(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where {N}
-    coord1 = get_coordinates(
-        M.M,
-        submanifold_component(x, Val(1)),
-        submanifold_component(v, Val(1)),
-        B,
-    )
-    coord2 = get_coordinates(
-        M.VS,
-        submanifold_component(x, Val(1)),
-        submanifold_component(v, Val(2)),
-        B,
-    )
+    px, ξx = submanifold_components(M.M, x)
+    ξvM, ξvF = submanifold_components(M.M, v)
+    coord1 = get_coordinates(M.M, px, ξvM, B)
+    coord2 = get_coordinates(M.VS, px, ξvF, B)
     return vcat(coord1, coord2)
 end
 
@@ -285,18 +277,10 @@ function get_coordinates(
     v,
     B::PrecomputedVectorBundleOrthonormalBasis,
 ) where {N}
-    coord1 = get_coordinates(
-        M.M,
-        submanifold_component(x, Val(1)),
-        submanifold_component(v, Val(1)),
-        B.base_basis,
-    )
-    coord2 = get_coordinates(
-        M.VS,
-        submanifold_component(x, Val(1)),
-        submanifold_component(v, Val(2)),
-        B.vec_basis,
-    )
+    px, ξx = submanifold_components(M.M, x)
+    ξvM, ξvF = submanifold_components(M.M, v)
+    coord1 = get_coordinates(M.M, px, ξvM, B.base_basis)
+    coord2 = get_coordinates(M.VS, px, ξvF, B.vec_basis)
     return vcat(coord1, coord2)
 end
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -1,4 +1,3 @@
-
 """
     VectorSpaceType
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -584,9 +584,9 @@ end
 size(x::FVector) = size(x.data)
 
 function submanifold_component(M::Manifold, x::FVector, i::Val)
-    return submanifold_components(M, x.data, i)
+    return submanifold_component(M, x.data, i)
 end
-submanifold_component(x::FVector, i::Val) = submanifold_components(x.data, i)
+submanifold_component(x::FVector, i::Val) = submanifold_component(x.data, i)
 
 submanifold_components(M::Manifold, x::FVector) = submanifold_components(M, x.data)
 submanifold_components(x::FVector) = submanifold_components(x.data)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -343,8 +343,9 @@ function get_vectors(M::VectorBundle, x, B::PrecomputedVectorBundleOrthonormalBa
 end
 
 get_vectors(::VectorBundleFibers, x, B::PrecomputedOrthonormalBasis) = B.vectors
-get_vectors(::VectorBundleFibers, x, B::PrecomputedDiagonalizingOrthonormalBasis) =
-    B.vectors
+function get_vectors(::VectorBundleFibers, x, B::PrecomputedDiagonalizingOrthonormalBasis)
+    return B.vectors
+end
 
 Base.@propagate_inbounds getindex(x::FVector, i) = getindex(x.data, i)
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -121,12 +121,14 @@ struct FVector{TType<:VectorSpaceType,TData}
     data::TData
 end
 
+const TFVector = FVector{TangentSpaceType}
+const CoTFVector = FVector{CotangentSpaceType}
+
 struct PrecomputedVectorBundleOrthonormalBasis{
     F,
     TBase<:AbstractPrecomputedOrthonormalBasis{F},
     TVec<:AbstractPrecomputedOrthonormalBasis{F},
 } <: AbstractPrecomputedOrthonormalBasis{F}
-
     base_basis::TBase
     vec_basis::TVec
 end
@@ -575,13 +577,13 @@ function similar_result_type(B::VectorBundleFibers, f, args::NTuple{N,Any}) wher
     T = typeof(reduce(+, one(eltype(eti)) for eti ∈ args))
     return T
 end
-function similar_result(M::Manifold, ::typeof(flat), w::FVector{TangentSpaceType}, x)
+function similar_result(M::Manifold, ::typeof(flat), w::TFVector, x)
     return FVector(CotangentSpace, similar(w.data))
 end
 
 size(x::FVector) = size(x.data)
 
-function similar_result(M::Manifold, ::typeof(sharp), w::FVector{CotangentSpaceType}, x)
+function similar_result(M::Manifold, ::typeof(sharp), w::CoTFVector, x)
     return FVector(TangentSpace, similar(w.data))
 end
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -29,7 +29,7 @@ abstract type VectorSpaceType end
 struct TangentSpaceType <: VectorSpaceType end
 struct CotangentSpaceType <: VectorSpaceType end
 
-TCoTSpaceType = Union{TangentSpaceType, CotangentSpaceType}
+TCoTSpaceType = Union{TangentSpaceType,CotangentSpaceType}
 
 const TangentSpace = TangentSpaceType()
 const CotangentSpace = CotangentSpaceType()
@@ -57,7 +57,7 @@ as a representation of vector spaces from a vector bundle but without
 storing the point at which a vector space is attached (which is specified
 separately in various functions).
 """
-struct VectorBundleFibers{TVS<:VectorSpaceType, TM<:Manifold}
+struct VectorBundleFibers{TVS<:VectorSpaceType,TM<:Manifold}
     VS::TVS
     M::TM
 end
@@ -72,7 +72,7 @@ CotangentBundleFibers(M::Manifold) = VectorBundleFibers(CotangentSpace, M)
 A vector space (fiber type `fiber` of a vector bundle) at point `x` from
 the manifold `fiber.M`.
 """
-struct VectorSpaceAtPoint{TFiber<:VectorBundleFibers, TX}
+struct VectorSpaceAtPoint{TFiber<:VectorBundleFibers,TX}
     fiber::TFiber
     x::TX
 end
@@ -102,13 +102,13 @@ end
 
 Vector bundle on manifold `M` of type `type`.
 """
-struct VectorBundle{TVS<:VectorSpaceType, TM<:Manifold} <: Manifold
+struct VectorBundle{TVS<:VectorSpaceType,TM<:Manifold} <: Manifold
     type::TVS
     M::TM
-    VS::VectorBundleFibers{TVS, TM}
+    VS::VectorBundleFibers{TVS,TM}
 end
-function VectorBundle(VS::TVS, M::TM) where {TVS<:VectorSpaceType, TM<:Manifold}
-    return VectorBundle{TVS, TM}(VS, M, VectorBundleFibers(VS, M))
+function VectorBundle(VS::TVS, M::TM) where {TVS<:VectorSpaceType,TM<:Manifold}
+    return VectorBundle{TVS,TM}(VS, M, VectorBundleFibers(VS, M))
 end
 TangentBundle{M} = VectorBundle{TangentSpaceType,M}
 TangentBundle(M::Manifold) = VectorBundle(TangentSpace, M)
@@ -129,7 +129,7 @@ end
 struct PrecomputedVectorBundleOrthonormalBasis{
     F,
     TBase<:AbstractPrecomputedOrthonormalBasis{F},
-    TVec<:AbstractPrecomputedOrthonormalBasis{F}
+    TVec<:AbstractPrecomputedOrthonormalBasis{F},
 } <: AbstractPrecomputedOrthonormalBasis{F}
 
     base_basis::TBase
@@ -139,7 +139,7 @@ end
 (+)(v1::FVector, v2::FVector) = FVector(v1.type, v1.data + v2.data)
 (-)(v1::FVector, v2::FVector) = FVector(v1.type, v1.data - v2.data)
 (-)(v::FVector) = FVector(v.type, -v.data)
-(*)(a::Number, v::FVector) = FVector(v.type, a*v.data)
+(*)(a::Number, v::FVector) = FVector(v.type, a * v.data)
 
 base_manifold(B::VectorBundleFibers) = base_manifold(B.M)
 base_manifold(B::VectorSpaceAtPoint) = base_manifold(B.fiber)
@@ -160,7 +160,7 @@ bundle_projection(B::VectorBundle, x) = submanifold_component(B.M, x, Val(1))
 Distance between vectors `v` and `w` from the vector space at point `x`
 from the manifold `M.M`, that is the base manifold of `M`.
 """
-distance(B::VectorBundleFibers, x, v, w) = norm(B, x, v-w)
+distance(B::VectorBundleFibers, x, v, w) = norm(B, x, v - w)
 @doc doc"""
     distance(B::VectorBundle, x, y)
 
@@ -242,9 +242,11 @@ function flat(M::Manifold, x, w::FVector)
     return v
 end
 function flat!(M::Manifold, v::FVector, x, w::FVector)
-    error("flat! not implemented for vector bundle fibers space " *
+    error(
+        "flat! not implemented for vector bundle fibers space " *
         "of type $(typeof(M)), vector of type $(typeof(v)), point of " *
-        "type $(typeof(x)) and vector of type $(typeof(w)).")
+        "type $(typeof(x)) and vector of type $(typeof(w)).",
+    )
 end
 
 function get_basis(M::VectorBundle, x, B::DiagonalizingOrthonormalBasis)
@@ -260,43 +262,48 @@ function get_basis(M::TangentBundleFibers, x, B::DiagonalizingOrthonormalBasis)
     return get_basis(M.M, x, B)
 end
 
-function get_coordinates(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_coordinates(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where {N}
     coord1 = get_coordinates(
         M.M,
         submanifold_component(x, Val(1)),
         submanifold_component(v, Val(1)),
-        B
+        B,
     )
     coord2 = get_coordinates(
         M.VS,
         submanifold_component(x, Val(1)),
         submanifold_component(v, Val(2)),
-        B
+        B,
     )
     return vcat(coord1, coord2)
 end
 
-function get_coordinates(M::VectorBundle, x, v, B::PrecomputedVectorBundleOrthonormalBasis) where N
+function get_coordinates(
+    M::VectorBundle,
+    x,
+    v,
+    B::PrecomputedVectorBundleOrthonormalBasis,
+) where {N}
     coord1 = get_coordinates(
         M.M,
         submanifold_component(x, Val(1)),
         submanifold_component(v, Val(1)),
-        B.base_basis
+        B.base_basis,
     )
     coord2 = get_coordinates(
         M.VS,
         submanifold_component(x, Val(1)),
         submanifold_component(v, Val(2)),
-        B.vec_basis
+        B.vec_basis,
     )
     return vcat(coord1, coord2)
 end
 
-function get_coordinates(M::TangentBundleFibers, x, v, B::AbstractBasis) where N
+function get_coordinates(M::TangentBundleFibers, x, v, B::AbstractBasis) where {N}
     return get_coordinates(M.M, x, v, B)
 end
 
-function get_vector(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where N
+function get_vector(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where {N}
     mdim = manifold_dimension(M.M)
     xp1 = submanifold_component(x, Val(1))
     v1 = get_vector(M.M, xp1, v[1:mdim], B)
@@ -304,7 +311,12 @@ function get_vector(M::VectorBundle, x, v, B::ArbitraryOrthonormalBasis) where N
     return ProductRepr(v1, v2)
 end
 
-function get_vector(M::VectorBundle, x, v, B::PrecomputedVectorBundleOrthonormalBasis) where N
+function get_vector(
+    M::VectorBundle,
+    x,
+    v,
+    B::PrecomputedVectorBundleOrthonormalBasis,
+) where {N}
     mdim = manifold_dimension(M.M)
     xp1 = submanifold_component(x, Val(1))
     v1 = get_vector(M.M, xp1, v[1:mdim], B.base_basis)
@@ -312,7 +324,7 @@ function get_vector(M::VectorBundle, x, v, B::PrecomputedVectorBundleOrthonormal
     return ProductRepr(v1, v2)
 end
 
-function get_vector(M::TangentBundleFibers, x, v, B::AbstractBasis) where N
+function get_vector(M::TangentBundleFibers, x, v, B::AbstractBasis) where {N}
     return get_vector(M.M, x, v, B)
 end
 
@@ -331,7 +343,8 @@ function get_vectors(M::VectorBundle, x, B::PrecomputedVectorBundleOrthonormalBa
 end
 
 get_vectors(::VectorBundleFibers, x, B::PrecomputedOrthonormalBasis) = B.vectors
-get_vectors(::VectorBundleFibers, x, B::PrecomputedDiagonalizingOrthonormalBasis) = B.vectors
+get_vectors(::VectorBundleFibers, x, B::PrecomputedDiagonalizingOrthonormalBasis) =
+    B.vectors
 
 Base.@propagate_inbounds getindex(x::FVector, i) = getindex(x.data, i)
 
@@ -342,18 +355,22 @@ Inner product of vectors `v` and `w` from the vector space of type `B.VS`
 at point `x` from manifold `B.M`.
 """
 function inner(B::VectorBundleFibers, x, v, w)
-    error("inner not defined for vector space family of type $(typeof(B)), " *
+    error(
+        "inner not defined for vector space family of type $(typeof(B)), " *
         "point of type $(typeof(x)) and " *
-        "vectors of types $(typeof(v)) and $(typeof(w)).")
+        "vectors of types $(typeof(v)) and $(typeof(w)).",
+    )
 end
 function inner(B::VectorBundleFibers{<:TangentSpaceType}, x, v, w)
     return inner(B.M, x, v, w)
 end
 function inner(B::VectorBundleFibers{<:CotangentSpaceType}, x, v, w)
-    return inner(B.M,
-                 x,
-                 sharp(B.M, x, FVector(CotangentSpace, v)).data,
-                 sharp(B.M, x, FVector(CotangentSpace, w)).data)
+    return inner(
+        B.M,
+        x,
+        sharp(B.M, x, FVector(CotangentSpace, v)).data,
+        sharp(B.M, x, FVector(CotangentSpace, w)).data,
+    )
 end
 @doc doc"""
     inner(B::VectorBundle, x, v, w)
@@ -532,9 +549,11 @@ function sharp(M::Manifold, x, w::FVector)
 end
 
 function sharp!(M::Manifold, v::FVector, x, w::FVector)
-    error("sharp! not implemented for vector bundle fibers space " *
+    error(
+        "sharp! not implemented for vector bundle fibers space " *
         "of type $(typeof(M)), vector of type $(typeof(v)), point of " *
-        "type $(typeof(x)) and vector of type $(typeof(w)).")
+        "type $(typeof(x)) and vector of type $(typeof(w)).",
+    )
 end
 
 similar(x::FVector) = FVector(x.type, similar(x.data))
@@ -559,7 +578,7 @@ Returns type of element of the array that will represent the result of
 function `f` for representing an operation with result in the vector space `VS`
 for manifold `M` on given arguments (passed at a tuple).
 """
-function similar_result_type(B::VectorBundleFibers, f, args::NTuple{N,Any}) where N
+function similar_result_type(B::VectorBundleFibers, f, args::NTuple{N,Any}) where {N}
     T = typeof(reduce(+, one(eltype(eti)) for eti ∈ args))
     return T
 end

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -136,6 +136,11 @@ end
 (-)(v::FVector) = FVector(v.type, -v.data)
 (*)(a::Number, v::FVector) = FVector(v.type, a * v.data)
 
+function copyto!(y::FVector, x::FVector)
+    copyto!(y.data, x.data)
+    return y
+end
+
 base_manifold(B::VectorBundleFibers) = base_manifold(B.M)
 base_manifold(B::VectorSpaceAtPoint) = base_manifold(B.fiber)
 base_manifold(B::VectorBundle) = base_manifold(B.M)
@@ -579,6 +584,14 @@ size(x::FVector) = size(x.data)
 function similar_result(M::Manifold, ::typeof(sharp), w::FVector{CotangentSpaceType}, x)
     return FVector(TangentSpace, similar(w.data))
 end
+
+function submanifold_component(M::Manifold, x::FVector, i::Val)
+    return submanifold_components(M, x.data, i)
+end
+submanifold_component(x::FVector, i::Val) = submanifold_components(x.data, i)
+
+submanifold_components(M::Manifold, x::FVector) = submanifold_components(M, x.data)
+submanifold_components(x::FVector) = submanifold_components(x.data)
 
 """
     vector_space_dimension(B::VectorBundleFibers)

--- a/src/ode.jl
+++ b/src/ode.jl
@@ -1,10 +1,12 @@
-function solve_exp_ode(M::MetricManifold,
-                       x,
-                       v,
-                       tspan;
-                       solver=AutoVern9(Rodas5()),
-                       backend = :default,
-                       kwargs...)
+function solve_exp_ode(
+    M::MetricManifold,
+    x,
+    v,
+    tspan;
+    solver = AutoVern9(Rodas5()),
+    backend = :default,
+    kwargs...,
+)
     n = length(x)
     iv = SVector{n}(1:n)
     ix = SVector{n}(n+1:2n)
@@ -19,7 +21,7 @@ function solve_exp_ode(M::MetricManifold,
         ddx = similar(u, Size(n))
         du = similar(u)
         Γ = christoffel_symbols_second(M, x; backend = backend)
-        @einsum ddx[k] = -Γ[k,i,j] * dx[i] * dx[j]
+        @einsum ddx[k] = -Γ[k, i, j] * dx[i] * dx[j]
         du[iv] .= ddx
         du[ix] .= dx
         return Base.convert(typeof(u), du)

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -147,11 +147,9 @@ See also: [`get_vector`](@ref), [`basis`](@ref)
 function get_coordinates(M::Manifold, x, v, B::AbstractBasis)
     error("get_coordinates not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)), tangent vector of type $(typeof(v)) and basis of type $(typeof(B)).")
 end
-
 function get_coordinates(M::Manifold, x, v, B::AbstractPrecomputedOrthonormalBasis{ℝ})
     return map(vb -> real(inner(M, x, v, vb)), get_vectors(M, x, B))
 end
-
 function get_coordinates(M::Manifold, x, v, B::AbstractPrecomputedOrthonormalBasis)
     return map(vb -> inner(M, x, v, vb), get_vectors(M, x, B))
 end
@@ -171,7 +169,6 @@ See also: [`get_coordinates`](@ref), [`basis`](@ref)
 function get_vector(M::Manifold, x, v, B::AbstractBasis)
     error("get_vector not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)), tangent vector of type $(typeof(v)) and basis of type $(typeof(B)).")
 end
-
 function get_vector(M::Manifold, x, v, B::AbstractPrecomputedOrthonormalBasis)
     # quite convoluted but:
     #  1) preserves the correct `eltype`
@@ -212,7 +209,6 @@ See also: [`get_coordinates`](@ref), [`get_vector`](@ref)
 function get_basis(M::Manifold, x, B::AbstractBasis)
     error("basis not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)) and basis of type $(typeof(B)).")
 end
-
 """
     get_basis(M::Manifold, x, B::ArbitraryOrthonormalBasis)
 
@@ -224,9 +220,7 @@ function get_basis(M::Manifold, x, B::ArbitraryOrthonormalBasis)
         get_vector(M, x, [ifelse(i == j, 1, 0) for j = 1:dim], B) for i = 1:dim
     ])
 end
-
 get_basis(M::Manifold, x, B::AbstractPrecomputedOrthonormalBasis) = B
-
 function get_basis(M::ArrayManifold, x, B::AbstractPrecomputedOrthonormalBasis{ℝ})
     bvectors = get_vectors(M, x, B)
     N = length(bvectors)
@@ -300,10 +294,10 @@ get_vectors(::Manifold, x, B::PrecomputedOrthonormalBasis) = B.vectors
 get_vectors(::Manifold, x, B::PrecomputedDiagonalizingOrthonormalBasis) = B.vectors
 
 # related to DefaultManifold; to be moved to ManifoldsBase.jl in the future
-using ManifoldsBase: DefaultManifold
 function get_coordinates(M::DefaultManifold, x, v, ::ArbitraryOrthonormalBasis)
     return reshape(v, manifold_dimension(M))
 end
+
 function get_vector(M::DefaultManifold, x, v, ::ArbitraryOrthonormalBasis)
     return reshape(v, representation_size(M))
 end

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -13,7 +13,7 @@ abstract type AbstractBasis{F} end
 
 The number system used as scalars in the given basis.
 """
-number_system(::AbstractBasis{F}) where F = F
+number_system(::AbstractBasis{F}) where {F} = F
 
 """
     AbstractOrthonormalBasis{F}
@@ -65,9 +65,10 @@ Available methods:
     an additional assumption (local metric tensor at a point where the
     basis is calculated has to be diagonal).
 """
-struct ProjectedOrthonormalBasis{Method, F} <: AbstractOrthonormalBasis{F} end
+struct ProjectedOrthonormalBasis{Method,F} <: AbstractOrthonormalBasis{F} end
 
-ProjectedOrthonormalBasis(method::Symbol, F::AbstractNumbers = ℝ) = ProjectedOrthonormalBasis{method, F}()
+ProjectedOrthonormalBasis(method::Symbol, F::AbstractNumbers = ℝ) =
+    ProjectedOrthonormalBasis{method,F}()
 
 @doc doc"""
     DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ)
@@ -78,13 +79,15 @@ tensor $R(u,v)w$ and where the direction `v` has curvature `0`.
 
 The type parameter `F` denotes the [`AbstractNumbers`](@ref) that will be used as scalars.
 """
-struct DiagonalizingOrthonormalBasis{TV, F} <: AbstractOrthonormalBasis{F}
+struct DiagonalizingOrthonormalBasis{TV,F} <: AbstractOrthonormalBasis{F}
     v::TV
 end
 
-DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ) = DiagonalizingOrthonormalBasis{typeof(v), F}(v)
+DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ) =
+    DiagonalizingOrthonormalBasis{typeof(v),F}(v)
 
-const ArbitraryOrDiagonalizingBasis = Union{ArbitraryOrthonormalBasis, DiagonalizingOrthonormalBasis}
+const ArbitraryOrDiagonalizingBasis =
+    Union{ArbitraryOrthonormalBasis,DiagonalizingOrthonormalBasis}
 
 """
     PrecomputedOrthonormalBasis(vectors::AbstractVector, F::AbstractNumbers = ℝ)
@@ -93,11 +96,13 @@ A precomputed orthonormal basis at a point on a manifold.
 
 The type parameter `F` denotes the [`AbstractNumbers`](@ref) that will be used as scalars.
 """
-struct PrecomputedOrthonormalBasis{TV<:AbstractVector, F} <: AbstractPrecomputedOrthonormalBasis{F}
+struct PrecomputedOrthonormalBasis{TV<:AbstractVector,F} <:
+       AbstractPrecomputedOrthonormalBasis{F}
     vectors::TV
 end
 
-PrecomputedOrthonormalBasis(vectors::AbstractVector, F::AbstractNumbers = ℝ) = PrecomputedOrthonormalBasis{typeof(vectors), F}(vectors)
+PrecomputedOrthonormalBasis(vectors::AbstractVector, F::AbstractNumbers = ℝ) =
+    PrecomputedOrthonormalBasis{typeof(vectors),F}(vectors)
 
 @doc doc"""
     DiagonalizingOrthonormalBasis(vectors, kappas, F::AbstractNumbers = ℝ)
@@ -108,7 +113,8 @@ tensor $R(u,v)w$ with eigenvalues `kappas` and where the direction `v` has curva
 
 The type parameter `F` denotes the [`AbstractNumbers`](@ref) that will be used as scalars.
 """
-struct PrecomputedDiagonalizingOrthonormalBasis{TV<:AbstractVector, TK<:AbstractVector, F} <: AbstractPrecomputedOrthonormalBasis{F}
+struct PrecomputedDiagonalizingOrthonormalBasis{TV<:AbstractVector,TK<:AbstractVector,F} <:
+       AbstractPrecomputedOrthonormalBasis{F}
     vectors::TV
     kappas::TK
 end
@@ -116,9 +122,12 @@ end
 function PrecomputedDiagonalizingOrthonormalBasis(
     vectors::AbstractVector,
     kappas::AbstractVector,
-    F::AbstractNumbers = ℝ
+    F::AbstractNumbers = ℝ,
 )
-    return PrecomputedDiagonalizingOrthonormalBasis{typeof(vectors), typeof(kappas), F}(vectors, kappas)
+    return PrecomputedDiagonalizingOrthonormalBasis{typeof(vectors),typeof(kappas),F}(
+        vectors,
+        kappas,
+    )
 end
 
 """
@@ -171,7 +180,7 @@ function get_vector(M::Manifold, x, v, B::AbstractPrecomputedOrthonormalBasis)
         vt = v[1] * bvectors[1]
         vout = similar(bvectors[1], eltype(vt))
         copyto!(vout, vt)
-        for i in 2:length(v)
+        for i = 2:length(v)
             vout += v[i] * bvectors[i]
         end
         return vout
@@ -179,7 +188,7 @@ function get_vector(M::Manifold, x, v, B::AbstractPrecomputedOrthonormalBasis)
         vt = v[1] .* bvectors[1]
         vout = similar(bvectors[1], eltype(vt))
         copyto!(vout, vt)
-        for i in 2:length(v)
+        for i = 2:length(v)
             vout .+= v[i] .* bvectors[i]
         end
         return vout
@@ -209,9 +218,9 @@ Compute the basis vectors of an [`ArbitraryOrthonormalBasis`](@ref).
 """
 function get_basis(M::Manifold, x, B::ArbitraryOrthonormalBasis)
     dim = manifold_dimension(M)
-    return PrecomputedOrthonormalBasis(
-        [get_vector(M, x, [ifelse(i == j, 1, 0) for j in 1:dim], B) for i in 1:dim]
-    )
+    return PrecomputedOrthonormalBasis([
+        get_vector(M, x, [ifelse(i == j, 1, 0) for j = 1:dim], B) for i = 1:dim
+    ])
 end
 
 get_basis(M::Manifold, x, B::AbstractPrecomputedOrthonormalBasis) = B
@@ -220,13 +229,16 @@ function get_basis(M::ArrayManifold, x, B::AbstractPrecomputedOrthonormalBasis{�
     bvectors = get_vectors(M, x, B)
     N = length(bvectors)
     M_dim = manifold_dimension(M)
-    N == M_dim || throw(ArgumentError("Incorrect number of basis vectors; expected: $M_dim, given: $N"))
-    for i in 1:N
+    N == M_dim ||
+    throw(ArgumentError("Incorrect number of basis vectors; expected: $M_dim, given: $N"))
+    for i = 1:N
         vi_norm = norm(M, x, bvectors[i])
-        isapprox(vi_norm, 1) || throw(ArgumentError("vector number $i is not normalized (norm = $vi_norm)"))
-        for j in i+1:N
+        isapprox(vi_norm, 1) ||
+        throw(ArgumentError("vector number $i is not normalized (norm = $vi_norm)"))
+        for j = i+1:N
             dot_val = real(inner(M, x, bvectors[i], bvectors[j]))
-            isapprox(dot_val, 0; atol = eps(eltype(x))) || throw(ArgumentError("vectors number $i and $j are not orthonormal (inner product = $dot_val)"))
+            isapprox(dot_val, 0; atol = eps(eltype(x))) ||
+            throw(ArgumentError("vectors number $i and $j are not orthonormal (inner product = $dot_val)"))
         end
     end
     return B
@@ -249,21 +261,24 @@ function _euclidean_basis_vector(x, i)
     return y
 end
 
-function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:svd, ℝ})
+function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:svd,ℝ})
     S = representation_size(M)
     PS = prod(S)
     dim = manifold_dimension(M)
     # projection
     # TODO: find a better way to obtain a basis of the ambient space
-    vs = [convert(Vector, reshape(project_tangent(M, x, _euclidean_basis_vector(x, i)), PS)) for i in eachindex(x)]
+    vs = [
+        convert(Vector, reshape(project_tangent(M, x, _euclidean_basis_vector(x, i)), PS))
+        for i in eachindex(x)
+    ]
     O = reduce(hcat, vs)
     # orthogonalization
     # TODO: try using rank-revealing QR here
     decomp = svd(O)
     rotated = Diagonal(decomp.S) * decomp.Vt
-    vecs = [collect(reshape(rotated[i,:], S)) for i in 1:dim]
+    vecs = [collect(reshape(rotated[i, :], S)) for i = 1:dim]
     # normalization
-    for i in 1:dim
+    for i = 1:dim
         i_norm = norm(M, x, vecs[i])
         vecs[i] /= i_norm
     end
@@ -292,7 +307,9 @@ function get_vector(M::DefaultManifold, x, v, ::ArbitraryOrthonormalBasis)
 end
 
 function get_basis(M::DefaultManifold, x, ::ArbitraryOrthonormalBasis)
-    return PrecomputedOrthonormalBasis([_euclidean_basis_vector(x, i) for i in eachindex(x)])
+    return PrecomputedOrthonormalBasis([
+        _euclidean_basis_vector(x, i) for i in eachindex(x)
+    ])
 end
 
 function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:gram_schmidt,ℝ}; kwargs...)
@@ -302,9 +319,9 @@ function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:gram_schmidt,�
     dim = manifold_dimension(M)
     N < dim && @warn "Input only has $(N) vectors, but manifold dimension is $(dim)."
     K = 0
-    @inbounds for n in 1:N
+    @inbounds for n = 1:N
         Ξₙ = project_tangent(M, x, E[n])
-        for k in 1:K
+        for k = 1:K
             Ξₙ .-= real(inner(M, x, Ξ[k], Ξₙ)) .* Ξ[k]
         end
         nrmΞₙ = norm(M, x, Ξₙ)
@@ -313,7 +330,7 @@ function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:gram_schmidt,�
             @goto skip
         end
         Ξₙ ./= nrmΞₙ
-        for k in 1:K
+        for k = 1:K
             if !isapprox(real(inner(M, x, Ξ[k], Ξₙ)), 0; kwargs...)
                 @warn "Input vector $(n) is not linearly independent of output basis vector $(k)."
                 @goto skip

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -225,16 +225,19 @@ function get_basis(M::ArrayManifold, x, B::AbstractPrecomputedOrthonormalBasis{â
     bvectors = get_vectors(M, x, B)
     N = length(bvectors)
     M_dim = manifold_dimension(M)
-    N == M_dim ||
-    throw(ArgumentError("Incorrect number of basis vectors; expected: $M_dim, given: $N"))
+    if N != M_dim
+        throw(ArgumentError("Incorrect number of basis vectors; expected: $M_dim, given: $N"))
+    end
     for i = 1:N
         vi_norm = norm(M, x, bvectors[i])
-        isapprox(vi_norm, 1) ||
-        throw(ArgumentError("vector number $i is not normalized (norm = $vi_norm)"))
+        if !isapprox(vi_norm, 1)
+            throw(ArgumentError("vector number $i is not normalized (norm = $vi_norm)"))
+        end
         for j = i+1:N
             dot_val = real(inner(M, x, bvectors[i], bvectors[j]))
-            isapprox(dot_val, 0; atol = eps(eltype(x))) ||
-            throw(ArgumentError("vectors number $i and $j are not orthonormal (inner product = $dot_val)"))
+            if !isapprox(dot_val, 0; atol = eps(eltype(x)))
+                throw(ArgumentError("vectors number $i and $j are not orthonormal (inner product = $dot_val)"))
+            end
         end
     end
     return B

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -67,8 +67,9 @@ Available methods:
 """
 struct ProjectedOrthonormalBasis{Method,F} <: AbstractOrthonormalBasis{F} end
 
-ProjectedOrthonormalBasis(method::Symbol, F::AbstractNumbers = ℝ) =
-    ProjectedOrthonormalBasis{method,F}()
+function ProjectedOrthonormalBasis(method::Symbol, F::AbstractNumbers = ℝ)
+    return ProjectedOrthonormalBasis{method,F}()
+end
 
 @doc doc"""
     DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ)
@@ -83,8 +84,9 @@ struct DiagonalizingOrthonormalBasis{TV,F} <: AbstractOrthonormalBasis{F}
     v::TV
 end
 
-DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ) =
-    DiagonalizingOrthonormalBasis{typeof(v),F}(v)
+function DiagonalizingOrthonormalBasis(v, F::AbstractNumbers = ℝ)
+    return DiagonalizingOrthonormalBasis{typeof(v),F}(v)
+end
 
 const ArbitraryOrDiagonalizingBasis =
     Union{ArbitraryOrthonormalBasis,DiagonalizingOrthonormalBasis}
@@ -101,8 +103,9 @@ struct PrecomputedOrthonormalBasis{TV<:AbstractVector,F} <:
     vectors::TV
 end
 
-PrecomputedOrthonormalBasis(vectors::AbstractVector, F::AbstractNumbers = ℝ) =
-    PrecomputedOrthonormalBasis{typeof(vectors),F}(vectors)
+function PrecomputedOrthonormalBasis(vectors::AbstractVector, F::AbstractNumbers = ℝ)
+    return PrecomputedOrthonormalBasis{typeof(vectors),F}(vectors)
+end
 
 @doc doc"""
     DiagonalizingOrthonormalBasis(vectors, kappas, F::AbstractNumbers = ℝ)

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -1,4 +1,3 @@
-
 """
     AbstractBasis{F}
 

--- a/src/orthonormal_bases.jl
+++ b/src/orthonormal_bases.jl
@@ -27,7 +27,7 @@ abstract type AbstractOrthonormalBasis{F} <: AbstractBasis{F} end
     AbstractPrecomputedOrthonormalBasis{F}
 
 Abstract type that represents an orthonormal basis of the tangent space at a point
-on a manifold. Tangent vectors can be obtained using function [`vectors`](@ref).
+on a manifold. Tangent vectors can be obtained using function [`get_vectors`](@ref).
 
 The vectors are not always fully precomputed because a partially precomputed
 basis may be enough for implementing [`get_vector`](@ref) and [`get_coordinates`](@ref).
@@ -142,7 +142,7 @@ Depending on the basis, `x` may not directly represent a point on the manifold.
 For example if a basis transported along a curve is used, `x` may be the coordinate
 along the curve.
 
-See also: [`get_vector`](@ref), [`basis`](@ref)
+See also: [`get_vector`](@ref), [`get_basis`](@ref)
 """
 function get_coordinates(M::Manifold, x, v, B::AbstractBasis)
     error("get_coordinates not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)), tangent vector of type $(typeof(v)) and basis of type $(typeof(B)).")
@@ -164,7 +164,7 @@ Depending on the basis, `x` may not directly represent a point on the manifold.
 For example if a basis transported along a curve is used, `x` may be the coordinate
 along the curve.
 
-See also: [`get_coordinates`](@ref), [`basis`](@ref)
+See also: [`get_coordinates`](@ref), [`get_basis`](@ref)
 """
 function get_vector(M::Manifold, x, v, B::AbstractBasis)
     error("get_vector not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)), tangent vector of type $(typeof(v)) and basis of type $(typeof(B)).")
@@ -202,12 +202,12 @@ represented by `x`.
 
 Returned object derives from [`AbstractBasis`](@ref) and may have a field `.vectors`
 that stores tangent vectors or it may store them implicitly, in which case
-the function [`vectors`](@ref) needs to be used to retrieve the basis vectors.
+the function [`get_vectors`](@ref) needs to be used to retrieve the basis vectors.
 
 See also: [`get_coordinates`](@ref), [`get_vector`](@ref)
 """
 function get_basis(M::Manifold, x, B::AbstractBasis)
-    error("basis not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)) and basis of type $(typeof(B)).")
+    error("get_basis not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)) and basis of type $(typeof(B)).")
 end
 """
     get_basis(M::Manifold, x, B::ArbitraryOrthonormalBasis)
@@ -290,7 +290,7 @@ end
 Get the basis vectors of basis `B` of the tangent space at point `x`.
 """
 function get_vectors(M::Manifold, x, B::AbstractBasis)
-    error("vectors not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)) and basis of type $(typeof(B)).")
+    error("get_vectors not implemented for manifold of type $(typeof(M)) a point of type $(typeof(x)) and basis of type $(typeof(B)).")
 end
 
 get_vectors(::Manifold, x, B::PrecomputedOrthonormalBasis) = B.vectors
@@ -340,6 +340,6 @@ function get_basis(M::Manifold, x, B::ProjectedOrthonormalBasis{:gram_schmidt,�
         K * real_dimension(number_system(B)) == dim && return PrecomputedOrthonormalBasis(Ξ)
         @label skip
     end
-    @warn "gram_schmidt only found $(K) orthonormal basis vectors, but manifold dimension is $(dim)."
+    @warn "get_basis with bases $(typeof(B)) only found $(K) orthonormal basis vectors, but manifold dimension is $(dim)."
     return PrecomputedOrthonormalBasis(Ξ)
 end

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -15,7 +15,6 @@ Reshape array `data` to size `Size` using method provided by `reshaper`.
 function make_reshape(reshaper::AbstractReshaper, ::Type{Size}, data) where {Size}
     error("make_reshape is not defined for reshaper of type $(typeof(reshaper)), size $(Size) and data of type $(typeof(data)).")
 end
-
 function make_reshape(::StaticReshaper, ::Type{Size}, data) where {Size}
     return SizedAbstractArray{Size}(data)
 end
@@ -131,7 +130,6 @@ function ProductArray(
     )
     return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
-
 function ProductArray(
     M::Type{ShapeSpecification{TRanges,Tuple{Size1,Size2,Size3},TReshapers}},
     data::TData,
@@ -144,7 +142,6 @@ function ProductArray(
     )
     return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
-
 function ProductArray(
     M::Type{ShapeSpecification{TRanges,TSizes,TReshapers}},
     data::TData,
@@ -158,7 +155,6 @@ function ProductArray(
     )
     return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
-
 ProductArray(M::ShapeSpecification, data) = ProductArray(typeof(M), data, M.reshapers)
 
 @doc doc"""
@@ -243,7 +239,9 @@ Base.dataids(x::ProductArray) = Base.dataids(x.data)
 @inline find_pv(::Any, rest) = find_pv(rest)
 
 size(x::ProductArray) = size(x.data)
+
 Base.@propagate_inbounds getindex(x::ProductArray, i) = getindex(x.data, i)
+
 Base.@propagate_inbounds setindex!(x::ProductArray, val, i) = setindex!(x.data, val, i)
 
 function (+)(
@@ -252,6 +250,7 @@ function (+)(
 ) where {ShapeSpec<:ShapeSpecification}
     return ProductArray(ShapeSpec, v1.data + v2.data, v1.reshapers)
 end
+
 function (-)(
     v1::ProductArray{ShapeSpec},
     v2::ProductArray{ShapeSpec},
@@ -261,6 +260,7 @@ end
 function (-)(v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification}
     return ProductArray(ShapeSpec, -v.data, v.reshapers)
 end
+
 function (*)(a::Number, v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification}
     return ProductArray(ShapeSpec, a * v.data, v.reshapers)
 end
@@ -298,7 +298,9 @@ struct ProductRepr{TM<:Tuple}
 end
 
 ProductRepr(points...) = ProductRepr{typeof(points)}(points)
+
 eltype(x::ProductRepr) = eltype(Tuple{map(eltype, submanifold_components(x))...})
+
 similar(x::ProductRepr) = ProductRepr(map(similar, submanifold_components(x))...)
 function similar(x::ProductRepr, ::Type{T}) where {T}
     return ProductRepr(map(t -> similar(t, T), submanifold_components(x))...)
@@ -312,10 +314,12 @@ end
 function (+)(v1::ProductRepr, v2::ProductRepr)
     return ProductRepr(map(+, submanifold_components(v1), submanifold_components(v2))...)
 end
+
 function (-)(v1::ProductRepr, v2::ProductRepr)
     return ProductRepr(map(-, submanifold_components(v1), submanifold_components(v2))...)
 end
 (-)(v::ProductRepr) = ProductRepr(map(-, submanifold_components(v)))
+
 (*)(a::Number, v::ProductRepr) = ProductRepr(map(t -> a * t, submanifold_components(v)))
 
 function Base.convert(::Type{TPR}, x::ProductRepr) where {TPR<:ProductRepr}

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -218,9 +218,11 @@ submanifold_components(::Any...)
 submanifold_components(M::Manifold, x) = submanifold_components(x)
 submanifold_components(x) = x.parts
 
-Base.BroadcastStyle(
+function Base.BroadcastStyle(
     ::Type{<:ProductArray{ShapeSpec}},
-) where {ShapeSpec<:ShapeSpecification} = Broadcast.ArrayStyle{ProductArray{ShapeSpec}}()
+) where {ShapeSpec<:ShapeSpecification}
+    return Broadcast.ArrayStyle{ProductArray{ShapeSpec}}()
+end
 
 function Base.similar(
     bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ProductArray{ShapeSpec}}},
@@ -247,26 +249,36 @@ size(x::ProductArray) = size(x.data)
 Base.@propagate_inbounds getindex(x::ProductArray, i) = getindex(x.data, i)
 Base.@propagate_inbounds setindex!(x::ProductArray, val, i) = setindex!(x.data, val, i)
 
-(+)(
+function (+)(
     v1::ProductArray{ShapeSpec},
     v2::ProductArray{ShapeSpec},
-) where {ShapeSpec<:ShapeSpecification} =
-    ProductArray(ShapeSpec, v1.data + v2.data, v1.reshapers)
-(-)(
+) where {ShapeSpec<:ShapeSpecification}
+    return ProductArray(ShapeSpec, v1.data + v2.data, v1.reshapers)
+end
+function (-)(
     v1::ProductArray{ShapeSpec},
     v2::ProductArray{ShapeSpec},
-) where {ShapeSpec<:ShapeSpecification} =
-    ProductArray(ShapeSpec, v1.data - v2.data, v1.reshapers)
-(-)(v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
-    ProductArray(ShapeSpec, -v.data, v.reshapers)
-(*)(a::Number, v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
-    ProductArray(ShapeSpec, a * v.data, v.reshapers)
+) where {ShapeSpec<:ShapeSpecification}
+    return ProductArray(ShapeSpec, v1.data - v2.data, v1.reshapers)
+end
+function (-)(v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification}
+    return ProductArray(ShapeSpec, -v.data, v.reshapers)
+end
+function (*)(a::Number, v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification}
+    return ProductArray(ShapeSpec, a * v.data, v.reshapers)
+end
 
 eltype(::Type{ProductArray{TM,TData,TV}}) where {TM,TData,TV} = eltype(TData)
-similar(x::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
-    ProductArray(ShapeSpec, similar(x.data), x.reshapers)
-similar(x::ProductArray{ShapeSpec}, ::Type{T}) where {ShapeSpec<:ShapeSpecification,T} =
-    ProductArray(ShapeSpec, similar(x.data, T), x.reshapers)
+
+function similar(x::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification}
+    return ProductArray(ShapeSpec, similar(x.data), x.reshapers)
+end
+function similar(
+    x::ProductArray{ShapeSpec},
+    ::Type{T},
+) where {ShapeSpec<:ShapeSpecification,T}
+    return ProductArray(ShapeSpec, similar(x.data, T), x.reshapers)
+end
 
 """
     ProductRepr(parts)

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -1,4 +1,3 @@
-
 abstract type AbstractReshaper end
 
 """

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -159,9 +159,7 @@ function ProductArray(
     return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
 
-function ProductArray(M::ShapeSpecification, data)
-    return ProductArray(typeof(M), data, M.reshapers)
-end
+ProductArray(M::ShapeSpecification, data) = ProductArray(typeof(M), data, M.reshapers)
 
 @doc doc"""
     prod_point(M::ShapeSpecification, pts...)

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -13,11 +13,11 @@ struct StaticReshaper <: AbstractReshaper end
 
 Reshape array `data` to size `Size` using method provided by `reshaper`.
 """
-function make_reshape(reshaper::AbstractReshaper, ::Type{Size}, data) where Size
+function make_reshape(reshaper::AbstractReshaper, ::Type{Size}, data) where {Size}
     error("make_reshape is not defined for reshaper of type $(typeof(reshaper)), size $(Size) and data of type $(typeof(data)).")
 end
 
-function make_reshape(::StaticReshaper, ::Type{Size}, data) where Size
+function make_reshape(::StaticReshaper, ::Type{Size}, data) where {Size}
     return SizedAbstractArray{Size}(data)
 end
 
@@ -28,7 +28,7 @@ Reshaper that constructs `Base.ReshapedArray`.
 """
 struct ArrayReshaper <: AbstractReshaper end
 
-function make_reshape(::ArrayReshaper, ::Type{Size}, data) where Size
+function make_reshape(::ArrayReshaper, ::Type{Size}, data) where {Size}
     return reshape(data, size_to_tuple(Size))
 end
 
@@ -75,7 +75,7 @@ represent points. In this case, `Sphere(2)` expects a three-element vector, so
 the corresponding size is `Tuple{3}`. On the other hand, `Rotations(2)`
 expects two-by-two matrices, so its size specification is `Tuple{2,2}`.
 """
-struct ShapeSpecification{TRanges, TSizes, TReshapers}
+struct ShapeSpecification{TRanges,TSizes,TReshapers}
     reshapers::TReshapers
 end
 
@@ -92,9 +92,9 @@ function ShapeSpecification(reshapers, manifolds::Manifold...)
     TSizes = Tuple{map(s -> Tuple{s...}, sizes)...}
     if isa(reshapers, AbstractReshaper)
         rtuple = map(m -> reshapers, manifolds)
-        return ShapeSpecification{TRanges, TSizes, typeof(rtuple)}(rtuple)
+        return ShapeSpecification{TRanges,TSizes,typeof(rtuple)}(rtuple)
     else
-        return ShapeSpecification{TRanges, TSizes, typeof(reshapers)}(reshapers)
+        return ShapeSpecification{TRanges,TSizes,typeof(reshapers)}(reshapers)
     end
 end
 
@@ -106,7 +106,14 @@ product manifold. `data` contains underlying representation of points
 arranged according to `TRanges` and `TSizes` from `shape`.
 Internal views for each specific sub-point are created and stored in `parts`.
 """
-struct ProductArray{TM<:ShapeSpecification,T,N,TData<:AbstractArray{T,N},TV<:Tuple,TReshaper} <: AbstractArray{T,N}
+struct ProductArray{
+    TM<:ShapeSpecification,
+    T,
+    N,
+    TData<:AbstractArray{T,N},
+    TV<:Tuple,
+    TReshaper,
+} <: AbstractArray{T,N}
     data::TData
     parts::TV
     reshapers::TReshaper
@@ -114,22 +121,43 @@ end
 
 # The two-argument version of this constructor is substantially faster than
 # the generic one.
-function ProductArray(M::Type{ShapeSpecification{TRanges, Tuple{Size1, Size2}, TReshapers}}, data::TData, reshapers) where {TRanges, Size1, Size2, TReshapers, T, N, TData<:AbstractArray{T,N}}
-    views = (make_reshape(reshapers[1], Size1, view(data, TRanges[1])),
-             make_reshape(reshapers[2], Size2, view(data, TRanges[2])))
-    return ProductArray{M, T, N, TData, typeof(views), typeof(reshapers)}(data, views, reshapers)
+function ProductArray(
+    M::Type{ShapeSpecification{TRanges,Tuple{Size1,Size2},TReshapers}},
+    data::TData,
+    reshapers,
+) where {TRanges,Size1,Size2,TReshapers,T,N,TData<:AbstractArray{T,N}}
+    views = (
+        make_reshape(reshapers[1], Size1, view(data, TRanges[1])),
+        make_reshape(reshapers[2], Size2, view(data, TRanges[2])),
+    )
+    return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
 
-function ProductArray(M::Type{ShapeSpecification{TRanges, Tuple{Size1, Size2, Size3}, TReshapers}}, data::TData, reshapers) where {TRanges, Size1, Size2, Size3, TReshapers, T, N, TData<:AbstractArray{T,N}}
-    views = (make_reshape(reshapers[1], Size1, view(data, TRanges[1])),
-             make_reshape(reshapers[2], Size2, view(data, TRanges[2])),
-             make_reshape(reshapers[3], Size3, view(data, TRanges[3])))
-    return ProductArray{M, T, N, TData, typeof(views), typeof(reshapers)}(data, views, reshapers)
+function ProductArray(
+    M::Type{ShapeSpecification{TRanges,Tuple{Size1,Size2,Size3},TReshapers}},
+    data::TData,
+    reshapers,
+) where {TRanges,Size1,Size2,Size3,TReshapers,T,N,TData<:AbstractArray{T,N}}
+    views = (
+        make_reshape(reshapers[1], Size1, view(data, TRanges[1])),
+        make_reshape(reshapers[2], Size2, view(data, TRanges[2])),
+        make_reshape(reshapers[3], Size3, view(data, TRanges[3])),
+    )
+    return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
 
-function ProductArray(M::Type{ShapeSpecification{TRanges, TSizes, TReshapers}}, data::TData, reshapers) where {TRanges, TSizes, TReshapers, T, N, TData<:AbstractArray{T,N}}
-    views = map((size, range, reshaper) -> make_reshape(reshaper, size, view(data, range)), size_to_tuple(TSizes), TRanges, reshapers)
-    return ProductArray{M, T, N, TData, typeof(views), typeof(reshapers)}(data, views, reshapers)
+function ProductArray(
+    M::Type{ShapeSpecification{TRanges,TSizes,TReshapers}},
+    data::TData,
+    reshapers,
+) where {TRanges,TSizes,TReshapers,T,N,TData<:AbstractArray{T,N}}
+    views = map(
+        (size, range, reshaper) -> make_reshape(reshaper, size, view(data, range)),
+        size_to_tuple(TSizes),
+        TRanges,
+        reshapers,
+    )
+    return ProductArray{M,T,N,TData,typeof(views),typeof(reshapers)}(data, views, reshapers)
 end
 
 function ProductArray(M::ShapeSpecification, data)
@@ -190,9 +218,14 @@ submanifold_components(::Any...)
 submanifold_components(M::Manifold, x) = submanifold_components(x)
 submanifold_components(x) = x.parts
 
-Base.BroadcastStyle(::Type{<:ProductArray{ShapeSpec}}) where ShapeSpec<:ShapeSpecification = Broadcast.ArrayStyle{ProductArray{ShapeSpec}}()
+Base.BroadcastStyle(
+    ::Type{<:ProductArray{ShapeSpec}},
+) where {ShapeSpec<:ShapeSpecification} = Broadcast.ArrayStyle{ProductArray{ShapeSpec}}()
 
-function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ProductArray{ShapeSpec}}}, ::Type{ElType}) where {ShapeSpec, ElType}
+function Base.similar(
+    bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ProductArray{ShapeSpec}}},
+    ::Type{ElType},
+) where {ShapeSpec,ElType}
     A = find_pv(bc)
     return ProductArray(ShapeSpec, similar(A.data, ElType), A.reshapers)
 end
@@ -214,14 +247,26 @@ size(x::ProductArray) = size(x.data)
 Base.@propagate_inbounds getindex(x::ProductArray, i) = getindex(x.data, i)
 Base.@propagate_inbounds setindex!(x::ProductArray, val, i) = setindex!(x.data, val, i)
 
-(+)(v1::ProductArray{ShapeSpec}, v2::ProductArray{ShapeSpec}) where ShapeSpec<:ShapeSpecification = ProductArray(ShapeSpec, v1.data + v2.data, v1.reshapers)
-(-)(v1::ProductArray{ShapeSpec}, v2::ProductArray{ShapeSpec}) where ShapeSpec<:ShapeSpecification = ProductArray(ShapeSpec, v1.data - v2.data, v1.reshapers)
-(-)(v::ProductArray{ShapeSpec}) where ShapeSpec<:ShapeSpecification = ProductArray(ShapeSpec, -v.data, v.reshapers)
-(*)(a::Number, v::ProductArray{ShapeSpec}) where ShapeSpec<:ShapeSpecification = ProductArray(ShapeSpec, a*v.data, v.reshapers)
+(+)(
+    v1::ProductArray{ShapeSpec},
+    v2::ProductArray{ShapeSpec},
+) where {ShapeSpec<:ShapeSpecification} =
+    ProductArray(ShapeSpec, v1.data + v2.data, v1.reshapers)
+(-)(
+    v1::ProductArray{ShapeSpec},
+    v2::ProductArray{ShapeSpec},
+) where {ShapeSpec<:ShapeSpecification} =
+    ProductArray(ShapeSpec, v1.data - v2.data, v1.reshapers)
+(-)(v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
+    ProductArray(ShapeSpec, -v.data, v.reshapers)
+(*)(a::Number, v::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
+    ProductArray(ShapeSpec, a * v.data, v.reshapers)
 
-eltype(::Type{ProductArray{TM, TData, TV}}) where {TM, TData, TV} = eltype(TData)
-similar(x::ProductArray{ShapeSpec}) where ShapeSpec<:ShapeSpecification = ProductArray(ShapeSpec, similar(x.data), x.reshapers)
-similar(x::ProductArray{ShapeSpec}, ::Type{T}) where {ShapeSpec<:ShapeSpecification, T} = ProductArray(ShapeSpec, similar(x.data, T), x.reshapers)
+eltype(::Type{ProductArray{TM,TData,TV}}) where {TM,TData,TV} = eltype(TData)
+similar(x::ProductArray{ShapeSpec}) where {ShapeSpec<:ShapeSpecification} =
+    ProductArray(ShapeSpec, similar(x.data), x.reshapers)
+similar(x::ProductArray{ShapeSpec}, ::Type{T}) where {ShapeSpec<:ShapeSpecification,T} =
+    ProductArray(ShapeSpec, similar(x.data, T), x.reshapers)
 
 """
     ProductRepr(parts)
@@ -262,8 +307,11 @@ function (-)(v1::ProductRepr, v2::ProductRepr)
     return ProductRepr(map(-, submanifold_components(v1), submanifold_components(v2))...)
 end
 (-)(v::ProductRepr) = ProductRepr(map(-, submanifold_components(v)))
-(*)(a::Number, v::ProductRepr) = ProductRepr(map(t -> a*t, submanifold_components(v)))
+(*)(a::Number, v::ProductRepr) = ProductRepr(map(t -> a * t, submanifold_components(v)))
 
-function Base.convert(::Type{TPR}, x::ProductRepr) where TPR<:ProductRepr
-    return ProductRepr(map(t -> convert(t...), ziptuples(tuple(TPR.parameters[1].parameters...), submanifold_components(x))))
+function Base.convert(::Type{TPR}, x::ProductRepr) where {TPR<:ProductRepr}
+    return ProductRepr(map(
+        t -> convert(t...),
+        ziptuples(tuple(TPR.parameters[1].parameters...), submanifold_components(x)),
+    ))
 end

--- a/src/projected_distribution.jl
+++ b/src/projected_distribution.jl
@@ -6,17 +6,27 @@ Generates a random point in ambient space of `m` and projects it to `m`
 using function `proj!`. Generated arrays are of type `TResult`, which can be
 specified by providing the `x` argument.
 """
-struct ProjectedPointDistribution{TResult, TM<:Manifold, TD<:Distribution, TProj} <: MPointDistribution{TM}
+struct ProjectedPointDistribution{TResult,TM<:Manifold,TD<:Distribution,TProj} <:
+       MPointDistribution{TM}
     manifold::TM
     d::TD
     proj!::TProj
 end
 
-function ProjectedPointDistribution(M::Manifold, d::Distribution, proj!, x::TResult) where TResult
-    return ProjectedPointDistribution{TResult, typeof(M), typeof(d), typeof(proj!)}(M, d, proj!)
+function ProjectedPointDistribution(
+    M::Manifold,
+    d::Distribution,
+    proj!,
+    x::TResult,
+) where {TResult}
+    return ProjectedPointDistribution{TResult,typeof(M),typeof(d),typeof(proj!)}(
+        M,
+        d,
+        proj!,
+    )
 end
 
-function rand(rng::AbstractRNG, d::ProjectedPointDistribution{TResult}) where TResult
+function rand(rng::AbstractRNG, d::ProjectedPointDistribution{TResult}) where {TResult}
     x = convert(TResult, rand(rng, d.d))
     d.proj!(d.manifold, x)
     return x
@@ -39,7 +49,13 @@ at point `x` and projects it to vector space of type `type` using function
 `project_vector!`, see [`project_vector`](@ref) for documentation.
 Generated arrays are of type `TResult`.
 """
-struct ProjectedFVectorDistribution{TResult, TSpace<:VectorBundleFibers, TX, TD<:Distribution, TProj} <: FVectorDistribution{TSpace, TX}
+struct ProjectedFVectorDistribution{
+    TResult,
+    TSpace<:VectorBundleFibers,
+    TX,
+    TD<:Distribution,
+    TProj,
+} <: FVectorDistribution{TSpace,TX}
     type::TSpace
     x::TX
     d::TD
@@ -51,23 +67,32 @@ function ProjectedFVectorDistribution(
     x,
     d::Distribution,
     project_vector!,
-    xt::TResult
-    ) where TResult
+    xt::TResult,
+) where {TResult}
     return ProjectedFVectorDistribution{
         TResult,
         typeof(type),
         typeof(x),
         typeof(d),
-        typeof(project_vector!)
-        }(type, x, d, project_vector!)
+        typeof(project_vector!),
+    }(
+        type,
+        x,
+        d,
+        project_vector!,
+    )
 end
 
-function rand(rng::AbstractRNG, d::ProjectedFVectorDistribution{TResult}) where TResult
+function rand(rng::AbstractRNG, d::ProjectedFVectorDistribution{TResult}) where {TResult}
     v = convert(TResult, reshape(rand(rng, d.d), size(d.x)))
     d.project_vector!(d.type, v, d.x, v)
     return v
 end
-function _rand!(rng::AbstractRNG, d::ProjectedFVectorDistribution, v::AbstractArray{<:Number})
+function _rand!(
+    rng::AbstractRNG,
+    d::ProjectedFVectorDistribution,
+    v::AbstractArray{<:Number},
+)
     # calling _rand!(rng, d.d, v) doesn't work for all arrays types
     copyto!(v, rand(rng, d))
     return v

--- a/src/projected_distribution.jl
+++ b/src/projected_distribution.jl
@@ -1,4 +1,3 @@
-
 """
     ProjectedPointDistribution(m::Manifold, d, proj!, x)
 

--- a/src/projected_distribution.jl
+++ b/src/projected_distribution.jl
@@ -27,18 +27,14 @@ end
 
 function rand(rng::AbstractRNG, d::ProjectedPointDistribution{TResult}) where {TResult}
     x = convert(TResult, rand(rng, d.d))
-    d.proj!(d.manifold, x)
-    return x
+    return d.proj!(d.manifold, x)
 end
 function _rand!(rng::AbstractRNG, d::ProjectedPointDistribution, x::AbstractArray{<:Number})
     _rand!(rng, d.d, x)
-    d.proj!(d.manifold, x)
-    return x
+    return d.proj!(d.manifold, x)
 end
 
-function support(d::ProjectedPointDistribution)
-    return MPointSupport(d.manifold)
-end
+support(d::ProjectedPointDistribution) = MPointSupport(d.manifold)
 
 """
     ProjectedFVectorDistribution(type::VectorBundleFibers, x, d, project_vector!)
@@ -84,8 +80,7 @@ end
 
 function rand(rng::AbstractRNG, d::ProjectedFVectorDistribution{TResult}) where {TResult}
     v = convert(TResult, reshape(rand(rng, d.d), size(d.x)))
-    d.project_vector!(d.type, v, d.x, v)
-    return v
+    return d.project_vector!(d.type, v, d.x, v)
 end
 function _rand!(
     rng::AbstractRNG,
@@ -93,10 +88,7 @@ function _rand!(
     v::AbstractArray{<:Number},
 )
     # calling _rand!(rng, d.d, v) doesn't work for all arrays types
-    copyto!(v, rand(rng, d))
-    return v
+    return copyto!(v, rand(rng, d))
 end
 
-function support(tvd::ProjectedFVectorDistribution)
-    return FVectorSupport(tvd.type, tvd.x)
-end
+support(tvd::ProjectedFVectorDistribution) = FVectorSupport(tvd.type, tvd.x)

--- a/src/projected_distribution.jl
+++ b/src/projected_distribution.jl
@@ -29,6 +29,7 @@ function rand(rng::AbstractRNG, d::ProjectedPointDistribution{TResult}) where {T
     x = convert(TResult, rand(rng, d.d))
     return d.proj!(d.manifold, x)
 end
+
 function _rand!(rng::AbstractRNG, d::ProjectedPointDistribution, x::AbstractArray{<:Number})
     _rand!(rng, d.d, x)
     return d.proj!(d.manifold, x)
@@ -82,6 +83,7 @@ function rand(rng::AbstractRNG, d::ProjectedFVectorDistribution{TResult}) where 
     v = convert(TResult, reshape(rand(rng, d.d), size(d.x)))
     return d.project_vector!(d.type, v, d.x, v)
 end
+
 function _rand!(
     rng::AbstractRNG,
     d::ProjectedFVectorDistribution,

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -109,9 +109,8 @@ struct GeodesicInterpolationWithinRadius{T} <: AbstractEstimationMethod
     radius::T
 
     function GeodesicInterpolationWithinRadius(radius::T) where {T}
-        radius > 0 ||
+        radius > 0 && return new{T}(radius)
         throw(DomainError("The radius must be strictly postive, received $(radius)."))
-        return new{T}(radius)
     end
 end
 
@@ -237,8 +236,9 @@ function mean!(
     kwargs...,
 )
     n = length(x)
-    (length(w) != n) &&
-    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    if length(w) != n
+        throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    end
     copyto!(y, x0)
     yold = similar_result(M, mean, y)
     v = zero_tangent_vector(M, y)
@@ -294,8 +294,9 @@ function mean!(
     kwargs...,
 )
     n = length(x)
-    (length(w) != n) &&
-    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    if length(w) != n
+        throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    end
     order = shuffle_rng === nothing ? (1:n) : shuffle(shuffle_rng, 1:n)
     @inbounds begin
         j = order[1]
@@ -365,8 +366,9 @@ function mean!(
     kwargs...,
 )
     n = length(x)
-    (length(w) != n) &&
-    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    if length(w) != n
+        throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    end
     copyto!(y, x0)
     yold = similar_result(M, median, y)
     ytmp = copy(yold)
@@ -507,8 +509,9 @@ function median!(
     kwargs...,
 )
     n = length(x)
-    (length(w) != n) &&
-    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    if length(w) != n
+        throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    end
     copyto!(y, x0)
     yold = similar_result(M, median, y)
     ytmp = copy(yold)
@@ -561,8 +564,9 @@ function var(M::Manifold, x::AbstractVector, m; corrected::Bool = true)
     return var(M, x, w, m; corrected = corrected)
 end
 
-var(M::Manifold, x::AbstractVector, w::AbstractWeights; kwargs...) =
-    mean_and_var(M, x, w; kwargs...)[2]
+function var(M::Manifold, x::AbstractVector, w::AbstractWeights; kwargs...)
+    return mean_and_var(M, x, w; kwargs...)[2]
+end
 var(M::Manifold, x::AbstractVector; kwargs...) = mean_and_var(M, x; kwargs...)[2]
 
 @doc doc"""
@@ -665,8 +669,9 @@ function mean_and_var(
     kwargs...,
 )
     n = length(x)
-    (length(w) != n) &&
-    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    if length(w) != n
+        throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    end
     order = shuffle_rng === nothing ? (1:n) : shuffle(shuffle_rng, 1:n)
     @inbounds begin
         j = order[1]

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1,5 +1,3 @@
-using StatsBase: AbstractWeights, ProbabilityWeights, values, varcorrection
-
 """
     GradientDescentEstimation <: AbstractEstimationMethod
 
@@ -170,7 +168,26 @@ The algorithm is further described in [^Afsari2013].
     > doi: [10.1137/12086282X](https://doi.org/10.1137/12086282X),
     > arxiv: [1201.0925](https://arxiv.org/abs/1201.0925)
 """
-mean(::Manifold, ::Any)
+mean(::Manifold, ::Any...)
+function mean(
+    M::Manifold,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
+    y = similar_result(M, mean, x[1])
+    return mean!(M, y, x, method...; kwargs...)
+end
+function mean(
+    M::Manifold,
+    x::AbstractVector,
+    w::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
+    y = similar_result(M, mean, x[1])
+    return mean!(M, y, x, w, method...; kwargs...)
+end
 
 @doc doc"""
     mean!(M::Manifold, y, x::AbstractVector[, w::AbstractWeights]; kwargs...)
@@ -185,29 +202,7 @@ mean(::Manifold, ::Any)
 
 Compute the [`mean`](@ref mean(::Manifold, args...)) in-place in `y`.
 """
-mean!(::Manifold, ::Any)
-
-function mean(
-    M::Manifold,
-    x::AbstractVector,
-    method::AbstractEstimationMethod...;
-    kwargs...,
-)
-    y = similar_result(M, mean, x[1])
-    return mean!(M, y, x, method...; kwargs...)
-end
-
-function mean(
-    M::Manifold,
-    x::AbstractVector,
-    w::AbstractVector,
-    method::AbstractEstimationMethod...;
-    kwargs...,
-)
-    y = similar_result(M, mean, x[1])
-    return mean!(M, y, x, w, method...; kwargs...)
-end
-
+mean!(::Manifold, ::Any...)
 function mean!(
     M::Manifold,
     y,
@@ -218,11 +213,9 @@ function mean!(
     w = _unit_weights(length(x))
     return mean!(M, y, x, w, method...; kwargs...)
 end
-
 function mean!(M::Manifold, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return mean!(M, y, x, w, GradientDescentEstimation(); kwargs...)
 end
-
 function mean!(
     M::Manifold,
     y,
@@ -352,7 +345,6 @@ function mean!(
     end
     return y
 end
-
 function mean!(
     M::Manifold,
     y,
@@ -443,7 +435,26 @@ The algorithm is further described in [^Bačák2014].
     > doi: [10.1137/140953393](https://doi.org/10.1137/140953393),
     > arxiv: [1210.2145](https://arxiv.org/abs/1210.2145)
 """
-median(::Manifold, ::Any)
+median(::Manifold, ::Any...)
+function median(
+    M::Manifold,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
+    y = similar_result(M, median, x[1])
+    return median!(M, y, x, method...; kwargs...)
+end
+function median(
+    M::Manifold,
+    x::AbstractVector,
+    w::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
+    y = similar_result(M, median, x[1])
+    return median!(M, y, x, w, method...; kwargs...)
+end
 
 @doc doc"""
     median!(M::Manifold, y, x::AbstractVector[, w::AbstractWeights]; kwargs...)
@@ -458,29 +469,7 @@ median(::Manifold, ::Any)
 
 computes the [`median`](@ref) in-place in `y`.
 """
-median!(::Manifold, ::Any)
-
-function median(
-    M::Manifold,
-    x::AbstractVector,
-    method::AbstractEstimationMethod...;
-    kwargs...,
-)
-    y = similar_result(M, median, x[1])
-    return median!(M, y, x, method...; kwargs...)
-end
-
-function median(
-    M::Manifold,
-    x::AbstractVector,
-    w::AbstractVector,
-    method::AbstractEstimationMethod...;
-    kwargs...,
-)
-    y = similar_result(M, median, x[1])
-    return median!(M, y, x, w, method...; kwargs...)
-end
-
+median!(::Manifold, ::Any...)
 function median!(
     M::Manifold,
     y,
@@ -491,11 +480,9 @@ function median!(
     w = _unit_weights(length(x))
     return median!(M, y, x, w, method...; kwargs...)
 end
-
 function median!(M::Manifold, y, x::AbstractVector, w::AbstractVector; kwargs...)
     return median!(M, y, x, w, CyclicProximalPointEstimation(); kwargs...)
 end
-
 function median!(
     M::Manifold,
     y,
@@ -548,7 +535,6 @@ can be activated by setting `corrected=true`. All further `kwargs...` are passed
 to the computation of the mean (if that is not provided).
 """
 var(M::Manifold, ::Any)
-
 function var(M::Manifold, x::AbstractVector, w::AbstractWeights, m; corrected::Bool = false)
     wv = convert(Vector, w)
     s = sum(eachindex(x, w)) do i
@@ -557,13 +543,11 @@ function var(M::Manifold, x::AbstractVector, w::AbstractWeights, m; corrected::B
     c = varcorrection(w, corrected)
     return c * s
 end
-
 function var(M::Manifold, x::AbstractVector, m; corrected::Bool = true)
     n = length(x)
     w = _unit_weights(n)
     return var(M, x, w, m; corrected = corrected)
 end
-
 function var(M::Manifold, x::AbstractVector, w::AbstractWeights; kwargs...)
     return mean_and_var(M, x, w; kwargs...)[2]
 end
@@ -604,8 +588,7 @@ Use the `method` for simultaneously computing the mean and variance. To use
 a mean-specific method, call [`mean`](@ref mean(::Manifold, args...)) and then
 [`var`](@ref).
 """
-mean_and_var(M::Manifold, ::Any)
-
+mean_and_var(M::Manifold, ::Any...)
 function mean_and_var(
     M::Manifold,
     x::AbstractVector,
@@ -618,7 +601,6 @@ function mean_and_var(
     v = var(M, x, w, m; corrected = corrected)
     return m, v
 end
-
 function mean_and_var(
     M::Manifold,
     x::AbstractVector,
@@ -785,7 +767,6 @@ function moment(
     end
     return s / sum(w)
 end
-
 function moment(M::Manifold, x::AbstractVector, k::Int, m = mean(M, x))
     w = _unit_weights(length(x))
     return moment(M, x, k, w, m)
@@ -802,11 +783,9 @@ function skewness(M::Manifold, x::AbstractVector, w::AbstractWeights)
     m, s = mean_and_std(M, x, w; corrected = false)
     return moment(M, x, 3, w, m) / s^3
 end
-
 function skewness(M::Manifold, x::AbstractVector, w::AbstractWeights, m)
     return moment(M, x, 3, w, m) / std(M, x, w, m; corrected = false)^3
 end
-
 function skewness(M::Manifold, x::AbstractVector, args...)
     w = _unit_weights(length(x))
     return skewness(M, x, w, args...)
@@ -823,11 +802,9 @@ function kurtosis(M::Manifold, x::AbstractVector, w::AbstractWeights)
     m, v = mean_and_var(M, x, w; corrected = false)
     return moment(M, x, 4, w, m) / v^2 - 3
 end
-
 function kurtosis(M::Manifold, x::AbstractVector, w::AbstractWeights, m)
     return moment(M, x, 4, w, m) / var(M, x, w, m; corrected = false)^2 - 3
 end
-
 function kurtosis(M::Manifold, x::AbstractVector, args...)
     w = _unit_weights(length(x))
     return kurtosis(M, x, w, args...)

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -109,7 +109,8 @@ struct GeodesicInterpolationWithinRadius{T} <: AbstractEstimationMethod
     radius::T
 
     function GeodesicInterpolationWithinRadius(radius::T) where {T}
-        radius > 0 || throw(DomainError("The radius must be strictly postive, received $(radius)."))
+        radius > 0 ||
+        throw(DomainError("The radius must be strictly postive, received $(radius)."))
         return new{T}(radius)
     end
 end
@@ -187,7 +188,12 @@ Compute the [`mean`](@ref mean(::Manifold, args...)) in-place in `y`.
 """
 mean!(::Manifold, ::Any)
 
-function mean(M::Manifold, x::AbstractVector, method::AbstractEstimationMethod...; kwargs...)
+function mean(
+    M::Manifold,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
     y = similar_result(M, mean, x[1])
     return mean!(M, y, x, method...; kwargs...)
 end
@@ -203,7 +209,13 @@ function mean(
     return mean!(M, y, x, w, method...; kwargs...)
 end
 
-function mean!(M::Manifold, y, x::AbstractVector, method::AbstractEstimationMethod...; kwargs...)
+function mean!(
+    M::Manifold,
+    y,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
     w = _unit_weights(length(x))
     return mean!(M, y, x, w, method...; kwargs...)
 end
@@ -219,28 +231,29 @@ function mean!(
     w::AbstractVector,
     ::GradientDescentEstimation;
     x0 = x[1],
-    stop_iter=100,
+    stop_iter = 100,
     retraction::AbstractRetractionMethod = ExponentialRetraction(),
     inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-    kwargs...
+    kwargs...,
 )
     n = length(x)
-    (length(w) != n) && throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    (length(w) != n) &&
+    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
     copyto!(y, x0)
     yold = similar_result(M, mean, y)
     v = zero_tangent_vector(M, y)
     vtmp = copy(v)
     α = w ./ cumsum(w)
-    for i=1:stop_iter
-        copyto!(yold,y)
+    for i = 1:stop_iter
+        copyto!(yold, y)
         # Online weighted mean
         @inbounds inverse_retract!(M, v, yold, x[1], inverse_retraction)
-        @inbounds for j in 2:n
+        @inbounds for j = 2:n
             inverse_retract!(M, vtmp, yold, x[j], inverse_retraction)
             v .+= α[j] .* (vtmp .- v)
         end
         retract!(M, y, yold, v, 0.5, retraction)
-        isapprox(M,y,yold; kwargs...) && break
+        isapprox(M, y, yold; kwargs...) && break
     end
     return y
 end
@@ -270,18 +283,19 @@ the (inverse) retraction.
 mean(::Manifold, ::AbstractVector, ::AbstractVector, ::GeodesicInterpolation)
 
 function mean!(
-        M::Manifold,
-        y,
-        x::AbstractVector,
-        w::AbstractVector,
-        ::GeodesicInterpolation;
-        shuffle_rng::Union{AbstractRNG,Nothing} = nothing,
-        retraction::AbstractRetractionMethod = ExponentialRetraction(),
-        inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-        kwargs...,
+    M::Manifold,
+    y,
+    x::AbstractVector,
+    w::AbstractVector,
+    ::GeodesicInterpolation;
+    shuffle_rng::Union{AbstractRNG,Nothing} = nothing,
+    retraction::AbstractRetractionMethod = ExponentialRetraction(),
+    inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
+    kwargs...,
 )
     n = length(x)
-    (length(w) != n) && throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    (length(w) != n) &&
+    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
     order = shuffle_rng === nothing ? (1:n) : shuffle(shuffle_rng, 1:n)
     @inbounds begin
         j = order[1]
@@ -290,7 +304,7 @@ function mean!(
     end
     v = zero_tangent_vector(M, y)
     ytmp = similar_result(M, mean, y)
-    @inbounds for i in 2:n
+    @inbounds for i = 2:n
         j = order[i]
         s += w[j]
         t = w[j] / s
@@ -344,27 +358,28 @@ function mean!(
     x::AbstractVector,
     w::AbstractVector,
     ::CyclicProximalPointEstimation;
-    x0=x[1],
-    stop_iter=1000000,
+    x0 = x[1],
+    stop_iter = 1000000,
     retraction::AbstractRetractionMethod = ExponentialRetraction(),
     inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-    kwargs...
+    kwargs...,
 )
     n = length(x)
-    (length(w) != n) && throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    (length(w) != n) &&
+    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
     copyto!(y, x0)
-    yold = similar_result(M,median,y)
+    yold = similar_result(M, median, y)
     ytmp = copy(yold)
-    v = zero_tangent_vector(M,y)
+    v = zero_tangent_vector(M, y)
     wv = convert(Vector, w) ./ sum(w)
-    for i=1:stop_iter
-        λ =  .5 / i
-        copyto!(yold,y)
-        for j in 1:n
-            @inbounds t = (2*λ*wv[j]) / (1 + 2*λ*wv[j])
+    for i = 1:stop_iter
+        λ = 0.5 / i
+        copyto!(yold, y)
+        for j = 1:n
+            @inbounds t = (2 * λ * wv[j]) / (1 + 2 * λ * wv[j])
             @inbounds inverse_retract!(M, v, y, x[j], inverse_retraction)
             retract!(M, ytmp, y, v, t, retraction)
-            copyto!(y,ytmp)
+            copyto!(y, ytmp)
         end
         isapprox(M, y, yold; kwargs...) && break
     end
@@ -443,7 +458,12 @@ computes the [`median`](@ref) in-place in `y`.
 """
 median!(::Manifold, ::Any)
 
-function median(M::Manifold, x::AbstractVector, method::AbstractEstimationMethod...; kwargs...)
+function median(
+    M::Manifold,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
     y = similar_result(M, median, x[1])
     return median!(M, y, x, method...; kwargs...)
 end
@@ -459,7 +479,13 @@ function median(
     return median!(M, y, x, w, method...; kwargs...)
 end
 
-function median!(M::Manifold, y, x::AbstractVector, method::AbstractEstimationMethod...; kwargs...)
+function median!(
+    M::Manifold,
+    y,
+    x::AbstractVector,
+    method::AbstractEstimationMethod...;
+    kwargs...,
+)
     w = _unit_weights(length(x))
     return median!(M, y, x, w, method...; kwargs...)
 end
@@ -474,27 +500,28 @@ function median!(
     x::AbstractVector,
     w::AbstractVector,
     ::CyclicProximalPointEstimation;
-    x0=x[1],
-    stop_iter=1000000,
+    x0 = x[1],
+    stop_iter = 1000000,
     retraction::AbstractRetractionMethod = ExponentialRetraction(),
     inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-    kwargs...
+    kwargs...,
 )
     n = length(x)
-    (length(w) != n) && throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
+    (length(w) != n) &&
+    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the median ($(n))."))
     copyto!(y, x0)
-    yold = similar_result(M,median,y)
+    yold = similar_result(M, median, y)
     ytmp = copy(yold)
-    v = zero_tangent_vector(M,y)
+    v = zero_tangent_vector(M, y)
     wv = convert(Vector, w) ./ sum(w)
-    for i=1:stop_iter
-        λ =  .5 / i
-        copyto!(yold,y)
-        for j in 1:n
-            @inbounds t = min( λ * wv[j] / distance(M,y,x[j]), 1. )
+    for i = 1:stop_iter
+        λ = 0.5 / i
+        copyto!(yold, y)
+        for j = 1:n
+            @inbounds t = min(λ * wv[j] / distance(M, y, x[j]), 1.0)
             @inbounds inverse_retract!(M, v, y, x[j], inverse_retraction)
             retract!(M, ytmp, y, v, t, retraction)
-            copyto!(y,ytmp)
+            copyto!(y, ytmp)
         end
         isapprox(M, y, yold; kwargs...) && break
     end
@@ -519,13 +546,7 @@ to the computation of the mean (if that is not provided).
 """
 var(M::Manifold, ::Any)
 
-function var(
-    M::Manifold,
-    x::AbstractVector,
-    w::AbstractWeights,
-    m;
-    corrected::Bool = false,
-)
+function var(M::Manifold, x::AbstractVector, w::AbstractWeights, m; corrected::Bool = false)
     wv = convert(Vector, w)
     s = sum(eachindex(x, w)) do i
         return @inbounds w[i] * distance(M, m, x[i])^2
@@ -534,18 +555,14 @@ function var(
     return c * s
 end
 
-function var(
-    M::Manifold,
-    x::AbstractVector,
-    m;
-    corrected::Bool = true,
-)
+function var(M::Manifold, x::AbstractVector, m; corrected::Bool = true)
     n = length(x)
     w = _unit_weights(n)
     return var(M, x, w, m; corrected = corrected)
 end
 
-var(M::Manifold, x::AbstractVector, w::AbstractWeights; kwargs...) = mean_and_var(M, x, w; kwargs...)[2]
+var(M::Manifold, x::AbstractVector, w::AbstractWeights; kwargs...) =
+    mean_and_var(M, x, w; kwargs...)[2]
 var(M::Manifold, x::AbstractVector; kwargs...) = mean_and_var(M, x; kwargs...)[2]
 
 @doc doc"""
@@ -590,7 +607,7 @@ function mean_and_var(
     x::AbstractVector,
     w::AbstractWeights,
     method::AbstractEstimationMethod...;
-    corrected=false,
+    corrected = false,
     kwargs...,
 )
     m = mean(M, x, w, method...; kwargs...)
@@ -602,7 +619,7 @@ function mean_and_var(
     M::Manifold,
     x::AbstractVector,
     method::AbstractEstimationMethod...;
-    corrected=true,
+    corrected = true,
     kwargs...,
 )
     n = length(x)
@@ -637,18 +654,19 @@ interpolation method.
     to give accurate results except on [`Euclidean`](@ref).
 """
 function mean_and_var(
-        M::Manifold,
-        x::AbstractVector,
-        w::AbstractWeights,
-        ::GeodesicInterpolation;
-        shuffle_rng::Union{AbstractRNG,Nothing} = nothing,
-        corrected = false,
-        retraction::AbstractRetractionMethod = ExponentialRetraction(),
-        inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-        kwargs...,
+    M::Manifold,
+    x::AbstractVector,
+    w::AbstractWeights,
+    ::GeodesicInterpolation;
+    shuffle_rng::Union{AbstractRNG,Nothing} = nothing,
+    corrected = false,
+    retraction::AbstractRetractionMethod = ExponentialRetraction(),
+    inverse_retraction::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
+    kwargs...,
 )
     n = length(x)
-    (length(w) != n) && throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
+    (length(w) != n) &&
+    throw(DimensionMismatch("The number of weights ($(length(w))) does not match the number of points for the mean ($(n))."))
     order = shuffle_rng === nothing ? (1:n) : shuffle(shuffle_rng, 1:n)
     @inbounds begin
         j = order[1]
@@ -658,7 +676,7 @@ function mean_and_var(
     v = zero_tangent_vector(M, y)
     M₂ = zero(eltype(v))
     ytmp = similar_result(M, mean, y)
-    @inbounds for i in 2:n
+    @inbounds for i = 2:n
         j = order[i]
         snew = s + w[j]
         t = w[j] / snew
@@ -691,13 +709,13 @@ See [`GeodesicInterpolationWithinRadius`](@ref) and
 for more information.
 """
 function mean_and_var(
-        M::Manifold,
-        x::AbstractVector,
-        w::AbstractWeights,
-        method::GeodesicInterpolationWithinRadius;
-        shuffle_rng = nothing,
-        corrected = false,
-        kwargs...,
+    M::Manifold,
+    x::AbstractVector,
+    w::AbstractWeights,
+    method::GeodesicInterpolationWithinRadius;
+    shuffle_rng = nothing,
+    corrected = false,
+    kwargs...,
 )
     y, v = mean_and_var(
         M,
@@ -750,7 +768,13 @@ Compute the `k`th central moment of points in `x` on manifold `M`. Optionally
 provide weights `w` and/or a precomputed
 [`mean`](@ref mean(::Manifold, args...)).
 """
-function moment(M::Manifold, x::AbstractVector, k::Int, w::AbstractWeights, m = mean(M, x, w))
+function moment(
+    M::Manifold,
+    x::AbstractVector,
+    k::Int,
+    w::AbstractWeights,
+    m = mean(M, x, w),
+)
     s = sum(eachindex(x, w)) do i
         return @inbounds w[i] * distance(M, m, x[i])^k
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,7 +31,6 @@ Compute the eigendecomposition of `x`. If `x` is a `StaticMatrix`, it is
 converted to a `Matrix` before the decomposition.
 """
 @inline eigen_safe(x; kwargs...) = eigen(x; kwargs...)
-
 @inline function eigen_safe(x::StaticMatrix; kwargs...)
     s = size(x)
     E = eigen!(Matrix(parent(x)); kwargs...)
@@ -45,7 +44,6 @@ Compute the matrix logarithm of `x`. If `x` is a `StaticMatrix`, it is
 converted to a `Matrix` before computing the log.
 """
 @inline log_safe(x) = log(x)
-
 @inline function log_safe(x::StaticMatrix)
     s = Size(x)
     return SizedMatrix{s[1],s[2]}(log(Matrix(parent(x))))
@@ -73,9 +71,9 @@ Converts a size given by `Tuple{N, M, ...}` into a tuple `(N, M, ...)`.
 Base.@pure size_to_tuple(::Type{S}) where {S<:Tuple} = tuple(S.parameters...)
 
 """
-    ziptuples(a, b)
+    ziptuples(a, b[, c[, d[, e]]])
 
-Zips tuples `a` and `b` in a fast, type-stable way. If they have different
+Zips tuples `a`, `b`, and remaining in a fast, type-stable way. If they have different
 lengths, the result is trimmed to the length of the shorter tuple.
 """
 @generated function ziptuples(a::NTuple{N,Any}, b::NTuple{M,Any}) where {N,M}
@@ -85,13 +83,6 @@ lengths, the result is trimmed to the length of the shorter tuple.
     end
     return ex
 end
-
-"""
-    ziptuples(a, b, c)
-
-Zips tuples `a`, `b` and `c` in a fast, type-stable way. If they have different
-lengths, the result is trimmed to the length of the shorter tuple.
-"""
 @generated function ziptuples(
     a::NTuple{N,Any},
     b::NTuple{M,Any},
@@ -103,13 +94,6 @@ lengths, the result is trimmed to the length of the shorter tuple.
     end
     return ex
 end
-
-"""
-    ziptuples(a, b, c, d)
-
-Zips tuples `a`, `b`, `c` and `d` in a fast, type-stable way. If they have
-different lengths, the result is trimmed to the length of the shorter tuple.
-"""
 @generated function ziptuples(
     a::NTuple{N,Any},
     b::NTuple{M,Any},
@@ -122,13 +106,6 @@ different lengths, the result is trimmed to the length of the shorter tuple.
     end
     return ex
 end
-
-"""
-    ziptuples(a, b, c, d, e)
-
-Zips tuples `a`, `b`, `c`, `d` and `e` in a fast, type-stable way. If they have
-different lengths, the result is trimmed to the length of the shorter tuple.
-"""
 @generated function ziptuples(
     a::NTuple{N,Any},
     b::NTuple{M,Any},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -83,7 +83,7 @@ lengths, the result is trimmed to the length of the shorter tuple.
     for i = 1:min(N, M)
         push!(ex.args, :((a[$i], b[$i])))
     end
-    ex
+    return ex
 end
 
 """
@@ -101,7 +101,7 @@ lengths, the result is trimmed to the length of the shorter tuple.
     for i = 1:min(N, M, L)
         push!(ex.args, :((a[$i], b[$i], c[$i])))
     end
-    ex
+    return ex
 end
 
 """
@@ -120,7 +120,7 @@ different lengths, the result is trimmed to the length of the shorter tuple.
     for i = 1:min(N, M, L, K)
         push!(ex.args, :((a[$i], b[$i], c[$i], d[$i])))
     end
-    ex
+    return ex
 end
 
 """
@@ -140,7 +140,7 @@ different lengths, the result is trimmed to the length of the shorter tuple.
     for i = 1:min(N, M, L, K, J)
         push!(ex.args, :((a[$i], b[$i], c[$i], d[$i], e[$i])))
     end
-    ex
+    return ex
 end
 
 # TODO: make a better implementation for StaticArrays

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,7 @@ Selects elements of tuple `t` at positions specified by the second argument.
 For example `select_from_tuple(("a", "b", "c"), Val((3, 1, 1)))` returns
 `("c", "a", "a")`.
 """
-@generated function select_from_tuple(t::NTuple{N, Any}, positions::Val{P}) where {N, P}
+@generated function select_from_tuple(t::NTuple{N,Any}, positions::Val{P}) where {N,P}
     for k in P
         (k < 0 || k > N) && error("positions must be between 1 and $N")
     end
@@ -92,7 +92,11 @@ end
 Zips tuples `a`, `b` and `c` in a fast, type-stable way. If they have different
 lengths, the result is trimmed to the length of the shorter tuple.
 """
-@generated function ziptuples(a::NTuple{N,Any}, b::NTuple{M,Any}, c::NTuple{L,Any}) where {N,M,L}
+@generated function ziptuples(
+    a::NTuple{N,Any},
+    b::NTuple{M,Any},
+    c::NTuple{L,Any},
+) where {N,M,L}
     ex = Expr(:tuple)
     for i = 1:min(N, M, L)
         push!(ex.args, :((a[$i], b[$i], c[$i])))
@@ -106,7 +110,12 @@ end
 Zips tuples `a`, `b`, `c` and `d` in a fast, type-stable way. If they have
 different lengths, the result is trimmed to the length of the shorter tuple.
 """
-@generated function ziptuples(a::NTuple{N,Any}, b::NTuple{M,Any}, c::NTuple{L,Any}, d::NTuple{K,Any}) where {N,M,L,K}
+@generated function ziptuples(
+    a::NTuple{N,Any},
+    b::NTuple{M,Any},
+    c::NTuple{L,Any},
+    d::NTuple{K,Any},
+) where {N,M,L,K}
     ex = Expr(:tuple)
     for i = 1:min(N, M, L, K)
         push!(ex.args, :((a[$i], b[$i], c[$i], d[$i])))
@@ -120,7 +129,13 @@ end
 Zips tuples `a`, `b`, `c`, `d` and `e` in a fast, type-stable way. If they have
 different lengths, the result is trimmed to the length of the shorter tuple.
 """
-@generated function ziptuples(a::NTuple{N,Any}, b::NTuple{M,Any}, c::NTuple{L,Any}, d::NTuple{K,Any}, e::NTuple{J,Any}) where {N,M,L,K,J}
+@generated function ziptuples(
+    a::NTuple{N,Any},
+    b::NTuple{M,Any},
+    c::NTuple{L,Any},
+    d::NTuple{K,Any},
+    e::NTuple{J,Any},
+) where {N,M,L,K,J}
     ex = Expr(:tuple)
     for i = 1:min(N, M, L, K, J)
         push!(ex.args, :((a[$i], b[$i], c[$i], d[$i], e[$i])))

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -20,6 +20,17 @@ include("utils.jl")
         @test (-fv1).type == TangentSpace
         @test isa(2*fv1, FVector)
         @test (2*fv1).type == TangentSpace
+
+        PM = ProductManifold(Sphere(2), Euclidean(2))
+        fv2 = FVector(TangentSpace, ProductRepr([1.0, 0.0, 0.0], [1.0, 2.0]))
+        @test submanifold_component(fv2, 1) == [1, 0, 0]
+        @test submanifold_component(fv2, 2) == [1, 2]
+        @test submanifold_component(fv2, Val(1)) == [1, 0, 0]
+        @test submanifold_component(fv2, Val(2)) == [1, 2]
+        @test submanifold_component(PM, fv2, 1) == [1, 0, 0]
+        @test submanifold_component(PM, fv2, 2) == [1, 2]
+        @test submanifold_component(PM, fv2, Val(1)) == [1, 0, 0]
+        @test submanifold_component(PM, fv2, Val(2)) == [1, 2]
     end
 
     types = [


### PR DESCRIPTION
This PR runs JuliaFormatter on everything in `src/` (see #94 ). It works toward enforcing a few conventions:
- No dangling `=` signs. If a "one-line" function is too long to fit in a line,
  then make it multiline
- Always add a newline between things of different types (struct/method/const)
- Always add a newline between methods for different functions (including mutating/nonmutating variants)
- Prefer to have no newline between methods for the same function; when reasonable, merge the docstrings.
- The mutating method always goes after the nonmutating method
- Try to simplify the codebase by identifying repeating patterns and introducing helper functions to replace them
- For routine mutating calls like `y .= `, `copyto!`, `fill!`, `mut!`, or our own mutating functions, consistently assume that the returned value is the mutated object, as convention dictates.
- All `import`/`using`/`include` are in the main module file.

A few incorrect docstrings and one or two small bugs are also fixed.